### PR TITLE
Reorganize nix to build via `nix-build default.nix`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
           nixbuild_ssh_key: ${{ secrets.nixbuild_ssh_key }}
         if: ${{ github.ref_name == 'master' }}
       - name: Build
-        run: nix-build test.nix
+        run: nix-build
       - name: Run pre-commit hooks
         run: nix-shell --run "pre-commit run --all"

--- a/default.nix
+++ b/default.nix
@@ -1,52 +1,5 @@
-{ lib
-, rustPlatform
-, nix-gitignore
-, makeWrapper
-, runCommand
-
-  # runtime dependencies
-, nix # for nix-prefetch-url
-, nix-prefetch-git
+{ system ? builtins.currentSystem
+, pins ? import ./npins
+, pkgs ? import pins.nixpkgs { inherit system; }
 }:
-let
-  paths = [
-    "^/src$"
-    "^/src/.+.rs$"
-    "^/npins$"
-    "^/npins/default.nix$"
-    "^/Cargo.lock$"
-    "^/Cargo.toml$"
-  ];
-
-  extractSource = src:
-    let baseDir = toString src; in
-    expressions:
-    builtins.path {
-      path = src;
-      filter = path:
-        let suffix = lib.removePrefix baseDir path; in
-        _: lib.any (r: builtins.match r suffix != null) expressions;
-      name = "source";
-    };
-
-  src = extractSource ./. paths;
-
-  cargoToml = builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"));
-  runtimePath = lib.makeBinPath [ nix nix-prefetch-git ];
-in
-rustPlatform.buildRustPackage {
-  pname = cargoToml.package.name;
-  version = cargoToml.package.version;
-  cargoLock = {
-    lockFile = src + "/Cargo.lock";
-    outputHashes."hubcaps-0.6.2" = "0xxla9d71ar0z9kmilx6qa077d3lq7zi3kjl234yjdmyb56n54iq";
-  };
-
-  inherit src;
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  postFixup = ''
-    wrapProgram $out/bin/npins --prefix PATH : "${runtimePath}"
-  '';
-}
+pkgs.callPackage ./npins.nix { }

--- a/npins.nix
+++ b/npins.nix
@@ -1,0 +1,52 @@
+{ lib
+, rustPlatform
+, nix-gitignore
+, makeWrapper
+, runCommand
+
+  # runtime dependencies
+, nix # for nix-prefetch-url
+, nix-prefetch-git
+}:
+let
+  paths = [
+    "^/src$"
+    "^/src/.+.rs$"
+    "^/npins$"
+    "^/npins/default.nix$"
+    "^/Cargo.lock$"
+    "^/Cargo.toml$"
+  ];
+
+  extractSource = src:
+    let baseDir = toString src; in
+    expressions:
+    builtins.path {
+      path = src;
+      filter = path:
+        let suffix = lib.removePrefix baseDir path; in
+        _: lib.any (r: builtins.match r suffix != null) expressions;
+      name = "source";
+    };
+
+  src = extractSource ./. paths;
+
+  cargoToml = builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"));
+  runtimePath = lib.makeBinPath [ nix nix-prefetch-git ];
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+  cargoLock = {
+    lockFile = src + "/Cargo.lock";
+    outputHashes."hubcaps-0.6.2" = "0xxla9d71ar0z9kmilx6qa077d3lq7zi3kjl234yjdmyb56n54iq";
+  };
+
+  inherit src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/npins --prefix PATH : "${runtimePath}"
+  '';
+}

--- a/test.nix
+++ b/test.nix
@@ -1,6 +1,0 @@
-{ system ? builtins.currentSystem }:
-let
-  pins = import ./npins;
-  pkgs = import pins.nixpkgs { inherit system; };
-in
-pkgs.callPackage ./default.nix { }


### PR DESCRIPTION
Previously npins could only be built via nix-build through
test.nix which was somewhat unexpected. With this commit
npins can still be built via callPackage as pkgs is an
argument to default.nix with default argument.

The GitHub test.yml was also adjusted.