### PR TITLE
ci: only add nixbuild.net action on the master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: nixbuild/nixbuild-action@v8
         with:
           nixbuild_ssh_key: ${{ secrets.nixbuild_ssh_key }}
+        if: ${{ github.ref_name == 'master' }}
       - name: Build
         run: nix-build test.nix
       - name: Run pre-commit hooks


### PR DESCRIPTION
The nixbuild.net credential aren't available to users other than me and
thus this step failed the CI. It should be sufficient to only run this
on master.