### PR TITLE
Fix darwin silicon

### DIFF
--- a/npins.nix
+++ b/npins.nix
@@ -3,6 +3,8 @@
 , nix-gitignore
 , makeWrapper
 , runCommand
+, stdenv
+, darwin
 
   # runtime dependencies
 , nix # for nix-prefetch-url
@@ -44,6 +46,7 @@ rustPlatform.buildRustPackage {
 
   inherit src;
 
+  buildInputs = lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ]);
   nativeBuildInputs = [ makeWrapper ];
 
   postFixup = ''

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 let
   pins = import ./npins;
   pkgs = import pins.nixpkgs { inherit system; };
+  inherit (pkgs) stdenv lib;
 
   pre-commit = (import pins."pre-commit-hooks.nix").run {
     src = ./.;
@@ -20,7 +21,8 @@ let
   };
 
 in
-pkgs.mkShell {
+pkgs.mkShell
+{
   nativeBuildInputs = with pkgs; [
     cargo
     rustc
@@ -32,5 +34,9 @@ pkgs.mkShell {
     git
   ];
 
-  inherit (pre-commit) shellHook;
+  # https://github.com/cachix/pre-commit-hooks.nix/issues/131
+  shellHook =
+    if (!(stdenv.isDarwin && stdenv.isAarch64))
+    then pre-commit.shellHook
+    else "";
 }


### PR DESCRIPTION
- Fixes the build: darwin needs the Security framework
- Fixes the shell: pre-commit-hooks.nix is currently broken for apple silicon so this PR disables its use for this platform for now