### PR TITLE
Run CI on darwin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: nixbuild/nix-quick-install-action@v6
@@ -18,3 +18,6 @@ jobs:
         run: nix-build
       - name: Run pre-commit hooks
         run: nix-shell --run "pre-commit run --all"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-10.15]


### PR DESCRIPTION
Execute tests on both ubuntu-latest and darwin-latest. The linux
built will be executed on nixbuild machines, the darwin build will
be executed "locally" on the GitHub workflow VM.

_NOTE_: We can't use `macos-latest` here because there is a problem with
nix-quick-install: https://github.com/nixbuild/nix-quick-install-action/issues/7