### PR TITLE
CLI Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ $ npins help
 npins 0.1.0
 
 USAGE:
-    npins [folder] <SUBCOMMAND>
+    npins [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
-ARGS:
-    <folder>    Base folder for npins.json and the boilerplate default.nix [env: NPINS_FOLDER=]  [default: npins]
+OPTIONS:
+    -d, --directory <folder>    Base folder for npins.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]
+                                [default: npins]
 
 SUBCOMMANDS:
     add       Adds a new pin entry
@@ -35,12 +36,15 @@ Intializes the npins directory. Running this multiple times will restore/upgrade
 pins.json
 
 USAGE:
-    npins init [FLAGS]
+    npins init [FLAGS] [OPTIONS]
 
 FLAGS:
-        --bare       Don't add an initial `nixpkgs` entry
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+        --bare    Don't add an initial `nixpkgs` entry
+    -h, --help    Prints help information
+
+OPTIONS:
+    -d, --directory <folder>    Base folder for npins.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]
+                                [default: npins]
 ```
 
 ## npins help add
@@ -53,11 +57,12 @@ USAGE:
     npins add [OPTIONS] <SUBCOMMAND>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help    Prints help information
 
 OPTIONS:
-    -n, --name <name>    
+    -d, --directory <folder>    Base folder for npins.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]
+                                [default: npins]
+    -n, --name <name>           
 
 SUBCOMMANDS:
     git               Track a git repository
@@ -74,11 +79,14 @@ npins-update 0.1.0
 Updates all or the given pin to the latest version
 
 USAGE:
-    npins update [name]
+    npins update [OPTIONS] [name]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help    Prints help information
+
+OPTIONS:
+    -d, --directory <folder>    Base folder for npins.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]
+                                [default: npins]
 
 ARGS:
     <name>    
@@ -91,11 +99,14 @@ npins-remove 0.1.0
 Removes one pin entry
 
 USAGE:
-    npins remove <name>
+    npins remove [OPTIONS] <name>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help    Prints help information
+
+OPTIONS:
+    -d, --directory <folder>    Base folder for npins.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]
+                                [default: npins]
 
 ARGS:
     <name>    

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ARGS:
 
 SUBCOMMANDS:
     add       Adds a new pin entry
+    fetch     Query some release information and then print out the entry
     help      Prints this message or the help of the given subcommand(s)
     init      Intializes the npins directory. Running this multiple times will restore/upgrade the `default.nix` and
               never touch your pins.json

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Intializes the npins directory. Running this multiple times will restore/upgrade
 pins.json
 
 USAGE:
-    npins init
+    npins init [FLAGS]
 
 FLAGS:
+        --bare       Don't add an initial `nixpkgs` entry
     -h, --help       Prints help information
     -V, --version    Prints version information
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ pub struct GitHubAddOpts {
     pub owner: String,
     pub repository: String,
 
-    #[structopt(default_value = "master")]
+    #[structopt(short, long, default_value = "master")]
     pub branch: String,
 }
 
@@ -158,7 +158,7 @@ pub struct GitAddOpts {
     url: String,
 
     /// Name of the branch to track.
-    #[structopt(default_value = "master")]
+    #[structopt(short, long, default_value = "master")]
     branch: String,
 }
 
@@ -281,10 +281,24 @@ pub enum Command {
     Remove(RemoveOpts),
 }
 
+use structopt::clap::AppSettings;
+
 #[derive(Debug, StructOpt)]
+#[structopt(
+    setting(AppSettings::ArgRequiredElseHelp),
+    global_setting(AppSettings::VersionlessSubcommands),
+    global_setting(AppSettings::ColoredHelp),
+    global_setting(AppSettings::ColorAuto)
+)]
 pub struct Opts {
     /// Base folder for npins.json and the boilerplate default.nix
-    #[structopt(default_value = "npins", env = "NPINS_FOLDER")]
+    #[structopt(
+        global = true,
+        short = "d",
+        long = "directory",
+        default_value = "npins",
+        env = "NPINS_DIRECTORY"
+    )]
     folder: std::path::PathBuf,
 
     #[structopt(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,9 @@ pub enum Command {
     /// Adds a new pin entry.
     Add(AddOpts),
 
+    /// Query some release information and then print out the entry
+    Fetch(AddOpts),
+
     /// Lists the current pin entries.
     Show,
 
@@ -346,6 +349,17 @@ impl Opts {
         Ok(())
     }
 
+    async fn fetch(&self, opts: &AddOpts) -> Result<()> {
+        let (_name, mut pin) = opts.run()?;
+        self.update_one(&mut pin)
+            .await
+            .context("Failed to fully fetch the pin")?;
+        serde_json::to_writer_pretty(std::io::stdout(), &pin)?;
+        println!();
+
+        Ok(())
+    }
+
     async fn update_one(&self, pin: &mut Pin) -> Result<()> {
         let diff = pin.update().await?;
         if diff.len() > 0 {
@@ -400,6 +414,7 @@ impl Opts {
             Command::Init => self.init()?,
             Command::Show => self.show()?,
             Command::Add(a) => self.add(a).await?,
+            Command::Fetch(a) => self.fetch(a).await?,
             Command::Update(o) => self.update(o).await?,
             Command::Remove(r) => self.remove(r)?,
         };


### PR DESCRIPTION
- Tweaked a few CLI options (for example, disabled version numbers for individual subcommands)
- Renamed some general CLI options (the positional for the `folder` is better off as a named argument to avoid parsing ambiguity; The `branch` input is now a named argument everywhere for consistency; etc.)
- add `--bare` to `npins init`, so that the initial `nixpkgs` entry is optional
- add a `fetch` command: it is like `add` and `update` in one but without touching the database (it prints the result to `stdout`). Useful for debugging.

Generally, the diff of the help in the README summarizes the changes rather well.