### PR TITLE
ux: improve the `show` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +124,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -507,6 +516,7 @@ dependencies = [
 name = "npins"
 version = "0.1.0"
 dependencies = [
+ "ansi_term 0.12.1",
  "anyhow",
  "async-trait",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ env_logger = { version = "^0.9.0", features = ["termcolor", "atty", "regex"], de
 log = "^0.4"
 reqwest = { version = "0.11.7", features = [ "rustls-tls" ], default-features = false }
 async-trait = "0.1.52"
+ansi_term = "0.12.1"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 
+use ansi_term::Style;
 use anyhow::{Context, Result};
 use diff::OptionExt;
 use pin::Pin;
@@ -295,7 +296,7 @@ impl Opts {
     fn show(&self) -> Result<()> {
         let pins = self.read_pins()?;
         for (name, pin) in pins.pins.iter() {
-            println!("\t{:<24}: {}", name, pin);
+            println!("\t{:<24}: {}", Style::new().bold().paint(name), pin);
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use anyhow::{Context, Result};
 use diff::OptionExt;
+use pin::Pin;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use structopt::StructOpt;
@@ -11,6 +12,7 @@ pub mod diff;
 pub mod git;
 pub mod github;
 pub mod nix;
+pub mod pin;
 pub mod pypi;
 
 #[async_trait::async_trait]
@@ -18,138 +20,6 @@ trait Updatable {
     type Output: diff::Diff + Serialize + Deserialize<'static> + std::fmt::Debug;
 
     async fn update(&self) -> Result<Self::Output>;
-}
-
-/// Create the `Pin` type
-///
-/// We need a type to unify over all possible way to pin a dependency. Normally, this would be done with a trait
-/// and trait objects. However, designing such a trait to be object-safe turns out to be highly non-trivial.
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(tag = "type")]
-pub enum Pin {
-    GitHub {
-        #[serde(flatten)]
-        input: github::PinInput,
-        #[serde(flatten)]
-        output: Option<github::PinOutput>,
-    },
-
-    GitHubRelease {
-        #[serde(flatten)]
-        input: github::ReleasePinInput,
-        #[serde(flatten)]
-        output: Option<github::ReleasePinOutput>,
-    },
-
-    Git {
-        #[serde(flatten)]
-        input: git::PinInput,
-        #[serde(flatten)]
-        output: Option<git::PinOutput>,
-    },
-
-    PyPi {
-        #[serde(flatten)]
-        input: pypi::PinInput,
-        #[serde(flatten)]
-        output: Option<pypi::PinOutput>,
-    },
-}
-
-impl Pin {
-    fn github(input: github::PinInput) -> Self {
-        Self::GitHub {
-            input,
-            output: None,
-        }
-    }
-
-    fn github_release(input: github::ReleasePinInput) -> Self {
-        Self::GitHubRelease {
-            input,
-            output: None,
-        }
-    }
-
-    fn git(input: git::PinInput) -> Self {
-        Self::Git {
-            input,
-            output: None,
-        }
-    }
-
-    fn pypi(input: pypi::PinInput) -> Self {
-        Self::PyPi {
-            input,
-            output: None,
-        }
-    }
-
-    async fn update(&mut self) -> Result<Vec<diff::Difference>> {
-        /* Use very explicit syntax to force the correct types and get good compile errors */
-        Ok(match self {
-            Self::GitHub { input, output } => {
-                let new_output: github::PinOutput =
-                    <github::PinInput as Updatable>::update(input).await?;
-                output.insert_diffed(new_output)
-            },
-
-            Self::GitHubRelease { input, output } => {
-                let new_output: github::ReleasePinOutput =
-                    <github::ReleasePinInput as Updatable>::update(input).await?;
-                output.insert_diffed(new_output)
-            },
-
-            Self::Git { input, output } => {
-                let new_output: git::PinOutput =
-                    <git::PinInput as Updatable>::update(input).await?;
-                output.insert_diffed(new_output)
-            },
-
-            Self::PyPi { input, output } => {
-                let new_output: pypi::PinOutput =
-                    <pypi::PinInput as Updatable>::update(input).await?;
-                output.insert_diffed(new_output)
-            },
-        })
-    }
-}
-
-impl std::fmt::Display for Pin {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::GitHub { input, output } => write!(
-                fmt,
-                "GitHub:{}/{}@{}",
-                input.repository,
-                input.owner,
-                output.as_ref().map_or("", |o| &o.revision)
-            ),
-
-            Self::GitHubRelease { input, output } => write!(
-                fmt,
-                "GitHubRelease:{}/{}@{}",
-                input.repository,
-                input.owner,
-                output.as_ref().map_or("", |o| &o.release_name)
-            ),
-
-            Self::Git { input, output } => write!(
-                fmt,
-                "Git:{}@{}",
-                input.repository_url,
-                output.as_ref().map_or("", |o| &o.revision)
-            ),
-
-            Self::PyPi { input, output } => write!(
-                fmt,
-                "PyPi: {}@{}",
-                input.name,
-                output.as_ref().map_or("", |o| &o.version)
-            ),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,8 +425,7 @@ impl Opts {
     fn show(&self) -> Result<()> {
         let pins = self.read_pins()?;
         for (name, pin) in pins.pins.iter() {
-            println!("{}:", name);
-            println!("\t{}", pin);
+            println!("\t{:<24}: {}", name, pin);
         }
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,62 +24,132 @@ trait Updatable {
 ///
 /// We need a type to unify over all possible way to pin a dependency. Normally, this would be done with a trait
 /// and trait objects. However, designing such a trait to be object-safe turns out to be highly non-trivial.
-/// (We'd need the `serde_erase` crate for `Deserialize` alone). Since writing this as an enum is extremely repetitive,
-/// this macro does the work for you.
-///
-/// For each pin type, call it with `(Name, lowename, InputType, OutputType)`. `Name` will be the name of the enum variant,
-/// `lower_name` will be used for the constructor.
-/// `InputType` and `OutputType` must adhere to the following requirements: TODO
-macro_rules! mkPin {
-    ( $(( $name:ident, $lower_name:ident, $input_name:path, $output_name:path )),* $(,)? ) => {
-        /* The type declaration */
-        #[derive(Debug, Serialize, Deserialize, Clone)]
-        #[serde(tag = "type")]
-        pub enum Pin {
-            $(
-                /* One variant per type. input and output are serialized to a common JSON dict using `flatten`. Output is optional. */
-                $name {
-                    #[serde(flatten)]
-                    input: $input_name,
-                    #[serde(flatten)]
-                    output: Option<$output_name>,
-                }
-            ),*
-        }
 
-        impl Pin {
-            /* Constructors */
-            $(fn $lower_name(input: $input_name) -> Self {
-                Self::$name { input, output: None }
-            })*
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum Pin {
+    GitHub {
+        #[serde(flatten)]
+        input: github::PinInput,
+        #[serde(flatten)]
+        output: Option<github::PinOutput>,
+    },
 
-            /* If an error is returned, `self` remains unchanged */
-            async fn update(&mut self) -> Result<Vec<diff::Difference>> {
-                Ok(match self {
-                    $(Self::$name { input, output } => {
-                        /* Use very explicit syntax to force the correct types and get good compile errors */
-                        let new_output: $output_name = <$input_name as Updatable>::update(input).await?;
-                        output.insert_diffed(new_output)
-                    }),*
-                })
-            }
-        }
+    GitHubRelease {
+        #[serde(flatten)]
+        input: github::ReleasePinInput,
+        #[serde(flatten)]
+        output: Option<github::ReleasePinOutput>,
+    },
 
-        impl std::fmt::Display for Pin {
-            fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-                match self {
-                    $(Self::$name { input, output } => write!(fmt, "{:?} -> {:?}", input, output)),*
-                }
-            }
-        }
-    };
+    Git {
+        #[serde(flatten)]
+        input: git::PinInput,
+        #[serde(flatten)]
+        output: Option<git::PinOutput>,
+    },
+
+    PyPi {
+        #[serde(flatten)]
+        input: pypi::PinInput,
+        #[serde(flatten)]
+        output: Option<pypi::PinOutput>,
+    },
 }
 
-mkPin! {
-    (GitHub, github, github::PinInput, github::PinOutput),
-    (GitHubRelease, github_release, github::ReleasePinInput, github::ReleasePinOutput),
-    (Git, git, git::PinInput, git::PinOutput),
-    (PyPi, pypi, pypi::PinInput, pypi::PinOutput),
+impl Pin {
+    fn github(input: github::PinInput) -> Self {
+        Self::GitHub {
+            input,
+            output: None,
+        }
+    }
+
+    fn github_release(input: github::ReleasePinInput) -> Self {
+        Self::GitHubRelease {
+            input,
+            output: None,
+        }
+    }
+
+    fn git(input: git::PinInput) -> Self {
+        Self::Git {
+            input,
+            output: None,
+        }
+    }
+
+    fn pypi(input: pypi::PinInput) -> Self {
+        Self::PyPi {
+            input,
+            output: None,
+        }
+    }
+
+    async fn update(&mut self) -> Result<Vec<diff::Difference>> {
+        /* Use very explicit syntax to force the correct types and get good compile errors */
+        Ok(match self {
+            Self::GitHub { input, output } => {
+                let new_output: github::PinOutput =
+                    <github::PinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+
+            Self::GitHubRelease { input, output } => {
+                let new_output: github::ReleasePinOutput =
+                    <github::ReleasePinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+
+            Self::Git { input, output } => {
+                let new_output: git::PinOutput =
+                    <git::PinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+
+            Self::PyPi { input, output } => {
+                let new_output: pypi::PinOutput =
+                    <pypi::PinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+        })
+    }
+}
+
+impl std::fmt::Display for Pin {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::GitHub { input, output } => write!(
+                fmt,
+                "GitHub:{}/{}@{}",
+                input.repository,
+                input.owner,
+                output.as_ref().map_or("", |o| &o.revision)
+            ),
+
+            Self::GitHubRelease { input, output } => write!(
+                fmt,
+                "GitHubRelease:{}/{}@{}",
+                input.repository,
+                input.owner,
+                output.as_ref().map_or("", |o| &o.release_name)
+            ),
+
+            Self::Git { input, output } => write!(
+                fmt,
+                "Git:{}@{}",
+                input.repository_url,
+                output.as_ref().map_or("", |o| &o.revision)
+            ),
+
+            Self::PyPi { input, output } => write!(
+                fmt,
+                "PyPi: {}@{}",
+                input.name,
+                output.as_ref().map_or("", |o| &o.version)
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,0 +1,135 @@
+use crate::*;
+
+/// Create the `Pin` type
+///
+/// We need a type to unify over all possible way to pin a dependency. Normally, this would be done with a trait
+/// and trait objects. However, designing such a trait to be object-safe turns out to be highly non-trivial.
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum Pin {
+    GitHub {
+        #[serde(flatten)]
+        input: github::PinInput,
+        #[serde(flatten)]
+        output: Option<github::PinOutput>,
+    },
+
+    GitHubRelease {
+        #[serde(flatten)]
+        input: github::ReleasePinInput,
+        #[serde(flatten)]
+        output: Option<github::ReleasePinOutput>,
+    },
+
+    Git {
+        #[serde(flatten)]
+        input: git::PinInput,
+        #[serde(flatten)]
+        output: Option<git::PinOutput>,
+    },
+
+    PyPi {
+        #[serde(flatten)]
+        input: pypi::PinInput,
+        #[serde(flatten)]
+        output: Option<pypi::PinOutput>,
+    },
+}
+
+impl Pin {
+    pub fn github(input: github::PinInput) -> Self {
+        Self::GitHub {
+            input,
+            output: None,
+        }
+    }
+
+    pub fn github_release(input: github::ReleasePinInput) -> Self {
+        Self::GitHubRelease {
+            input,
+            output: None,
+        }
+    }
+
+    pub fn git(input: git::PinInput) -> Self {
+        Self::Git {
+            input,
+            output: None,
+        }
+    }
+
+    pub fn pypi(input: pypi::PinInput) -> Self {
+        Self::PyPi {
+            input,
+            output: None,
+        }
+    }
+
+    pub async fn update(&mut self) -> Result<Vec<diff::Difference>> {
+        /* Use very explicit syntax to force the correct types and get good compile errors */
+        Ok(match self {
+            Self::GitHub { input, output } => {
+                let new_output: github::PinOutput =
+                    <github::PinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+
+            Self::GitHubRelease { input, output } => {
+                let new_output: github::ReleasePinOutput =
+                    <github::ReleasePinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+
+            Self::Git { input, output } => {
+                let new_output: git::PinOutput =
+                    <git::PinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+
+            Self::PyPi { input, output } => {
+                let new_output: pypi::PinOutput =
+                    <pypi::PinInput as Updatable>::update(input).await?;
+                output.insert_diffed(new_output)
+            },
+        })
+    }
+}
+
+impl std::fmt::Display for Pin {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::GitHub { input, output } => write!(
+                fmt,
+                "GitHub:{}/{}@{} ({})",
+                input.repository,
+                input.owner,
+                output.as_ref().map_or("", |o| &o.revision),
+                input.branch
+            ),
+
+            Self::GitHubRelease { input, output } => write!(
+                fmt,
+                "GitHubRelease:{}/{}@{}",
+                input.repository,
+                input.owner,
+                output.as_ref().map_or("", |o| &o.release_name)
+            ),
+
+            Self::Git { input, output } => write!(
+                fmt,
+                "Git:{}@{} ({})",
+                input.repository_url,
+                output.as_ref().map_or("", |o| &o.revision),
+                input.branch
+            ),
+
+            Self::PyPi { input, output } => write!(
+                fmt,
+                "PyPi: {}@{}",
+                input.name,
+                output.as_ref().map_or("", |o| &o.version)
+            ),
+        }
+    }
+}


### PR DESCRIPTION
This PR aims at improving the UX around the `npins show` command by making the output easier to digest and more condensed:

```
$ npins show
   nixpkgs: GitHub:nixpkgs/nixos@8f39ad3da14ce78daf249c8291a4e43a17bbcf98 (nixpkgs-unstable)
   pre-commit-hooks.nix: GitHub:pre-commit-hooks.nix/cachix@433808cba23975201a48a3bb8ebc76029191fafd (master)
```

Relevant changes:
- Refactoring the `mkPin` macro into explicit Pin types: this was necessary in order to provide custom Display implementations for different pin types
- Extracted `Pin` to `src/pin.rs` module
- Changed the `show` function to yield the above
- Added `ansi_term` crate and used it to print pin names in bold in the show command