### PR TITLE
Fix stupid bug

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,7 +50,7 @@ impl GitHubAddOpts {
             self.repository.clone(),
             match &self.more.branch {
                 Some(branch) => {
-                    let pin = git::GitPin::github(&self.repository, &self.owner, branch.clone());
+                    let pin = git::GitPin::github(&self.owner, &self.repository, branch.clone());
                     let version = self.more.at.as_ref().map(|at| git::GitRevision {
                         revision: at.clone(),
                     });


### PR DESCRIPTION
`npins add github` was confusing `user` and `repo` if a `branch` was set.