### PR TITLE
README: Add Matrix badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Issues][issues-shield]][issues-url]
 [![PRs][pr-shield]][pr-url]
 [![Tests][test-shield]][test-url]
+![Matrix][matrix-url]
 
 <!-- teaser -->
 <br />
@@ -255,3 +256,4 @@ ARGS:
 [test-url]: https://github.com/andir/npins/actions
 [pr-shield]: https://img.shields.io/github/issues-pr/andir/npins.svg?style=for-the-badge
 [pr-url]: https://github.com/andir/npins/pulls
+[matrix-url]: https://img.shields.io/matrix/npins:kack.it?label=Chat%20on%20Matrix?style=for-the-badge

--- a/readme.post.md
+++ b/readme.post.md
@@ -10,3 +10,4 @@
 [test-url]: https://github.com/andir/npins/actions
 [pr-shield]: https://img.shields.io/github/issues-pr/andir/npins.svg?style=for-the-badge
 [pr-url]: https://github.com/andir/npins/pulls
+[matrix-url]: https://img.shields.io/matrix/npins:kack.it?label=Chat%20on%20Matrix?style=for-the-badge

--- a/readme.pre.md
+++ b/readme.pre.md
@@ -6,6 +6,7 @@
 [![Issues][issues-shield]][issues-url]
 [![PRs][pr-shield]][pr-url]
 [![Tests][test-shield]][test-url]
+![Matrix][matrix-url]
 
 <!-- teaser -->
 <br />


### PR DESCRIPTION
The badge should start working as soon as previewing access for guests is granted to the room. If this is undesired, I could alternatively create a badge that displays the channel name instead of its user count.