### PR TITLE
Nixpkgs mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You may also use attributes from the JSON file, they are exposed 1:1. For exampl
 ```console
 $ npins help
 npins 0.1.0
+Pin dependencies and track upstream repositories
 
 USAGE:
     npins [OPTIONS] <SUBCOMMAND>

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ USAGE:
 
 FLAGS:
     -n, --dry-run    Don't actually apply the changes
+    -f, --force      Overwrite existing pins with the same name
     -h, --help       Prints help information
 
 OPTIONS:

--- a/npins.nix
+++ b/npins.nix
@@ -37,6 +37,7 @@ let
 
   cargoToml = builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"));
   runtimePath = lib.makeBinPath [ nix nix-prefetch-git git ];
+
   self = rustPlatform.buildRustPackage {
     pname = cargoToml.package.name;
     version = cargoToml.package.version;
@@ -54,6 +55,10 @@ let
 
     postFixup = ''
       wrapProgram $out/bin/npins --prefix PATH : "${runtimePath}"
+    '';
+
+    postInstall = ''
+      ln -s $out/bin/npins $out/bin/npins-pkgs
     '';
 
     meta.tests = pkgs.callPackage ./test.nix { npins = self; };

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,7 @@ let
       rustfmt.enable = true;
       update-readme = {
         enable = true;
-        files = "((readme\\.pre\\.md|readme\\.post\\.md|^readme\\.nix)|\\.rs)$";
+        files = "((readme\\.md\\.in|^readme\\.nix)|\\.rs)$";
         entry = toString (pkgs.writeShellScript "update-readme" ''
           ${pkgs.nix}/bin/nix-build ${toString ./readme.nix} -o readme && cp readme README.md
           exec ${pkgs.git}/bin/git diff --quiet --exit-code -- README.md

--- a/src/git.rs
+++ b/src/git.rs
@@ -485,7 +485,7 @@ pub async fn fetch_ref(repo: &Url, ref_: impl AsRef<str>) -> Result<RemoteInfo> 
 
     anyhow::ensure!(
         !remotes.is_empty(),
-        "git ls-remote output is empty. Are you sure '{}' exists?",
+        "git ls-remote output is empty. Are you sure '{}' exists? Note: If you want to tag a revision, you need to also specify a branch.",
         ref_,
     );
     anyhow::ensure!(

--- a/test.nix
+++ b/test.nix
@@ -122,6 +122,20 @@ in
     '';
   };
 
+  force-add = mkGitTest {
+    name = "force-add";
+    inherit gitRepo;
+    commands = ''
+      npins init --bare
+      npins add git http://localhost:8000/foo -b test-branch
+      ! npins add git http://localhost:8000/foo -b test-branch
+      npins add -f git http://localhost:8000/foo
+
+      V=$(jq -r .pins.foo.version npins/sources.json)
+      [[ "$V" = "v0.2" ]]
+    '';
+  };
+
   gitDependency = mkGitTest {
     name = "from-git-repo";
     inherit gitRepo;
@@ -173,6 +187,19 @@ in
 
       V=$(jq -r .pins.bar.version npins/sources.json)
       [[ "$V" = "v0.2" ]]
+    '';
+  };
+
+  nixpkgs = mkGitTest {
+    name = "npins-pkgs";
+    inherit gitRepo;
+    commands = ''
+      ! npins-pkgs init --bare # Command should not exist
+      npins init --bare
+      npins add git http://localhost:8000/foo -b test-branch
+      npins-pkgs add git http://localhost:8000/foo -b test-branch
+
+      cmp ./sources.json ./npins/sources.json
     '';
   };
 }


### PR DESCRIPTION
For usage within nixpkgs, we want the `sources.json` to be level with the current folder, and we don't need a `default.nix` since it will be included globally in nixpkgs itself.