### PR TITLE
Fix private repos and add filename support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -74,15 +74,15 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 
 [[package]]
 name = "cfg-if"
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "log",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -269,9 +269,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "itoa"
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "lock_api"
@@ -424,9 +424,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "parking_lot"
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -576,15 +576,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64",
  "bytes",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "indexmap",
  "itoa",
@@ -837,9 +837,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1129,46 +1129,60 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -10,7 +10,8 @@
       "branch": "nixpkgs-unstable",
       "revision": "a529f0c125a78343b145a8eb2b915b0295e4f459",
       "url": "https://github.com/nixos/nixpkgs/archive/a529f0c125a78343b145a8eb2b915b0295e4f459.tar.gz",
-      "hash": "0d945bdpsxaqz4d9hvsmzhcbriqwga3i0bf1ppj6lrrbqhr4pj7v"
+      "hash": "0d945bdpsxaqz4d9hvsmzhcbriqwga3i0bf1ppj6lrrbqhr4pj7v",
+      "filename": "npins-github-nixpkgs.tar.gz"
     },
     "pre-commit-hooks.nix": {
       "type": "Git",
@@ -22,8 +23,9 @@
       "branch": "master",
       "revision": "ff9c0b459ddc4b79c06e19d44251daa8e9cd1746",
       "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/ff9c0b459ddc4b79c06e19d44251daa8e9cd1746.tar.gz",
-      "hash": "0z09ndxvbk6w4j28lzgj0b9qqcbwrvr58c0xsm0rf0xsdipi0nwf"
+      "hash": "0z09ndxvbk6w4j28lzgj0b9qqcbwrvr58c0xsm0rf0xsdipi0nwf",
+      "filename": "npins-github-pre-commit-hooks.nix.tar.gz"
     }
   },
-  "version": 3
+  "version": 4
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -74,7 +74,8 @@ impl Updatable for Pin {
          * https://releases.nixos.org/nixos/21.11/nixos-21.11.335807.df4f1f7cc3f
          */
         let hash =
-            nix::nix_prefetch_tarball(&version.url, Some(Self::calc_filename(&version.url)?)).await?;
+            nix::nix_prefetch_tarball(&version.url, Some(Self::calc_filename(&version.url)?))
+                .await?;
 
         Ok(ChannelHash { hash })
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -161,9 +161,9 @@ impl Repository {
                         ]
                         .iter(),
                     );
-                url.set_query(Some(&format!("sha={}", revision)));
+                url.query_pairs_mut().append_pair("sha", revision);
                 if let Some(token) = private_token {
-                    url.set_query(Some(&format!("private_token={}", token)));
+                    url.query_pairs_mut().append_pair("private_token", token);
                 }
                 Some(url)
             },
@@ -203,9 +203,9 @@ impl Repository {
                         ]
                         .iter(),
                     );
-                url.set_query(Some(&format!("ref={}", tag)));
+                url.query_pairs_mut().append_pair("ref", tag);
                 if let Some(token) = private_token {
-                    url.set_query(Some(&format!("private_token={}", token)));
+                    url.query_pairs_mut().append_pair("private_token", token);
                 }
                 Some(url)
             },

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -6,12 +6,21 @@ pub struct PrefetchInfo {
     hash: String,
 }
 
-pub async fn nix_prefetch_tarball(url: impl AsRef<str>) -> Result<String> {
+pub async fn nix_prefetch_tarball(
+    url: impl AsRef<str>,
+    filename: Option<impl AsRef<str>>,
+) -> Result<String> {
     let url = url.as_ref();
-    let output = tokio::process::Command::new("nix-prefetch-url")
-        .arg("--unpack") // force calculation of the unpacked NAR hash
+    let mut cmd = tokio::process::Command::new("nix-prefetch-url");
+    cmd.arg("--unpack") // force calculation of the unpacked NAR hash
         .arg("--type")
-        .arg("sha256")
+        .arg("sha256");
+
+    if let Some(filename) = filename {
+        cmd.arg("--name").arg(filename.as_ref());
+    }
+
+    let output = cmd
         .arg(url)
         .output()
         .await

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -226,25 +226,59 @@ fn upgrade_v3_pin(name: &str, raw_pin: &mut Map<String, Value>) -> Result<()> {
     /* Only the fields we care about */
     #[derive(Debug, Deserialize)]
     #[serde(tag = "type")]
+    enum Repository {
+        GitLab {
+            repo_path: String,
+        },
+        GitHub {
+            repo: String,
+        },
+        /* Don't care */
+        #[serde(other)]
+        Invalid,
+    }
+
+    /* Only the fields we care about */
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "type")]
     enum OldPin {
         Channel {
             url: url::Url,
+        },
+        Git {
+            repository: Repository,
+        },
+        GitRelease {
+            repository: Repository,
         },
         #[serde(other)]
         Invalid,
     }
     let pin: OldPin = serde_json::from_value(serde_json::Value::Object(raw_pin.clone()))?;
-    log::warn!("{:?}", pin);
     match pin {
-        OldPin::Channel {
-            url
-        } => {
+        OldPin::Channel { url } => {
             raw_pin.insert("filename".into(), json!(channel::Pin::calc_filename(&url)?));
+        },
+        OldPin::GitRelease { repository, .. } |
+        OldPin::Git { repository, .. } => {
+            let filename = match repository {
+                Repository::GitLab { repo_path } => {
+                    Some(format!("npins-gitlab-{}.tar.gz", repo_path.split('/').last().unwrap().to_owned()))
+                },
+                Repository::GitHub { repo } => {
+                    Some(format!("npins-github-{}.tar.gz", repo))
+                },
+                _ => {
+                    None
+                }
+            };
+            if let Some(filename) = filename {
+                raw_pin.insert("filename".into(), json!(filename));
+            }
         },
         /* Do nothing here */
         OldPin::Invalid => {},
     }
-    log::warn!("{:?}", raw_pin);
 
     Ok(())
 }
@@ -326,12 +360,12 @@ mod test {
                     "nixos-mailserver".into() => Pin::Git {
                         input: git::GitPin::git("https://gitlab.com/simple-nixos-mailserver/nixos-mailserver.git".parse().unwrap(), "nixos-21.11".into()),
                         version: Some(git::GitRevision { revision: "6e3a7b2ea6f0d68b82027b988aa25d3423787303".into() }),
-                        hashes: Some(git::OptionalUrlHashes { url: None, hash: "1i56llz037x416bw698v8j6arvv622qc0vsycd20lx3yx8n77n44".into() } ),
+                        hashes: Some(git::OptionalUrlHashes { url: None, hash: "1i56llz037x416bw698v8j6arvv622qc0vsycd20lx3yx8n77n44".into(), filename: None } ),
                     },
                     "nixpkgs".into() => Pin::Git {
                         input: git::GitPin::github("nixos", "nixpkgs", "nixpkgs-unstable".into()),
                         version: Some(git::GitRevision { revision: "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2".into() }),
-                        hashes: Some(git::OptionalUrlHashes { url: Some("https://github.com/nixos/nixpkgs/archive/5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2.tar.gz".parse().unwrap()), hash: "1r74afnalgcbpv7b9sbdfbnx1kfj0kp1yfa60bbbv27n36vqdhbb".into() }),
+                        hashes: Some(git::OptionalUrlHashes { url: Some("https://github.com/nixos/nixpkgs/archive/5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2.tar.gz".parse().unwrap()), hash: "1r74afnalgcbpv7b9sbdfbnx1kfj0kp1yfa60bbbv27n36vqdhbb".into(), filename: None }),
                     },
                     "streamlit".into() => Pin::PyPi {
                         input: pypi::Pin { name: "streamlit".into(), version_upper_bound: None },

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -259,18 +259,14 @@ fn upgrade_v3_pin(name: &str, raw_pin: &mut Map<String, Value>) -> Result<()> {
         OldPin::Channel { url } => {
             raw_pin.insert("filename".into(), json!(channel::Pin::calc_filename(&url)?));
         },
-        OldPin::GitRelease { repository, .. } |
-        OldPin::Git { repository, .. } => {
+        OldPin::GitRelease { repository, .. } | OldPin::Git { repository, .. } => {
             let filename = match repository {
-                Repository::GitLab { repo_path } => {
-                    Some(format!("npins-gitlab-{}.tar.gz", repo_path.split('/').last().unwrap().to_owned()))
-                },
-                Repository::GitHub { repo } => {
-                    Some(format!("npins-github-{}.tar.gz", repo))
-                },
-                _ => {
-                    None
-                }
+                Repository::GitLab { repo_path } => Some(format!(
+                    "npins-gitlab-{}.tar.gz",
+                    repo_path.split('/').last().unwrap().to_owned()
+                )),
+                Repository::GitHub { repo } => Some(format!("npins-github-{}.tar.gz", repo)),
+                _ => None,
             };
             if let Some(filename) = filename {
                 raw_pin.insert("filename".into(), json!(filename));


### PR DESCRIPTION
I'm very sorry for this.

So essentially when using a private repos, the `sha1=` parameter was **replaced** by the private token rather than the private token being appended to the query params.
This would have been an easy fix but that actually results in `&` being part of the derivation name which is invalid. This is why I now generate filenames for all the pins that are fetchurl'ed. Yay.