### PR TITLE
HACK: introduce metadata for newly added pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tokio",
+ "toml",
  "url",
 ]
 
@@ -888,6 +889,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,13 @@ reqwest = { version = "0.11.7", features = [ "rustls-tls" ], default-features = 
 async-trait = "0.1.52"
 lenient_semver_parser = { version = "0.4.2", default-features = false }
 lenient_version = { version = "0.4.2" }
+toml = { version = "0.5", optional = true }
 
 [dev-dependencies]
 envtestkit = "1.1.2"
+
+
+[features]
+cargo-lock = ["tokio/fs","tokio/io-util", "toml"]
+
+default = [ "cargo-lock" ]

--- a/import-cargo-lock.nix
+++ b/import-cargo-lock.nix
@@ -1,0 +1,226 @@
+{ fetchgit, fetchurl, lib, runCommand, cargo, jq, writeText, remarshal }:
+
+{
+  # Cargo lock file
+  lockFile ? null
+
+  # Cargo lock file contents as string
+, lockFileContents ? null
+
+  # the lock file contents as Nix data structure
+, lockFileData ? null
+
+  # Hashes for git dependencies.
+, outputHashes ? { }
+} @ args:
+
+# FIXME: ensure that at most one is selected
+assert lib.any (x: x != null) [ lockFile lockFileContents lockFileData ];
+
+let
+  # Parse a git source into different components.
+  parseGit = src:
+    let
+      parts = builtins.match ''git\+([^?]+)(\?(rev|tag|branch)=(.*))?#(.*)'' src;
+      type = builtins.elemAt parts 2; # rev, tag or branch
+      value = builtins.elemAt parts 3;
+    in
+    if parts == null then null
+    else {
+      url = builtins.elemAt parts 0;
+      sha = builtins.elemAt parts 4;
+    } // lib.optionalAttrs (type != null) { inherit type value; };
+
+  # shadows args.lockFile
+  lockFile =
+    if args ? lockFile then args.lockFile
+    else
+      (if lockFileData != null then runCommand "Cargo.lock" { data = builtins.toJSON lockFileData; nativeBuildInputs = [ remarshal ]; passAsFile = [ "data" ]; } "remarshal -if json -of toml < $dataFile > $out"
+      else if args ? lockFileContents != null then writeText "Cargo.lock" args.lockFileContents
+      else builtins.throw "invariant violated, need either lockFile, lockfFileData or lockFileContents to be non-null");
+
+  # shadows args.lockFileContents
+  lockFileContents =
+    if lockFile != null
+    then builtins.readFile lockFile
+    else args.lockFileContents;
+
+  packages = (if lockFileData != null then lockFileData else builtins.fromTOML lockFileContents).package;
+
+  # There is no source attribute for the source package itself. But
+  # since we do not want to vendor the source package anyway, we can
+  # safely skip it.
+  depPackages = (builtins.filter (p: p ? "source") packages);
+
+  # Create dependent crates from packages.
+  #
+  # Force evaluation of the git SHA -> hash mapping, so that an error is
+  # thrown if there are stale hashes. We cannot rely on gitShaOutputHash
+  # being evaluated otherwise, since there could be no git dependencies.
+  depCrates = builtins.deepSeq (gitShaOutputHash) (builtins.map mkCrate depPackages);
+
+  # Map package name + version to git commit SHA for packages with a git source.
+  namesGitShas = builtins.listToAttrs (
+    builtins.map nameGitSha (builtins.filter (pkg: lib.hasPrefix "git+" pkg.source) depPackages)
+  );
+
+  nameGitSha = pkg:
+    let gitParts = parseGit pkg.source; in
+    {
+      name = "${pkg.name}-${pkg.version}";
+      value = gitParts.sha;
+    };
+
+  # Convert the attrset provided through the `outputHashes` argument to a
+  # a mapping from git commit SHA -> output hash.
+  #
+  # There may be multiple different packages with different names
+  # originating from the same git repository (typically a Cargo
+  # workspace). By using the git commit SHA as a universal identifier,
+  # the user does not have to specify the output hash for every package
+  # individually.
+  gitShaOutputHash = lib.mapAttrs'
+    (nameVer: hash:
+      let
+        unusedHash = throw "A hash was specified for ${nameVer}, but there is no corresponding git dependency.";
+        rev = namesGitShas.${nameVer} or unusedHash;
+      in
+      {
+        name = rev;
+        value = hash;
+      })
+    outputHashes;
+
+  # We can't use the existing fetchCrate function, since it uses a
+  # recursive hash of the unpacked crate.
+  fetchCrate = pkg:
+    assert lib.assertMsg (pkg ? checksum) ''
+      Package ${pkg.name} does not have a checksum.
+      Please note that the Cargo.lock format where checksums used to be listed
+      under [metadata] is not supported.
+      If that is the case, running `cargo update` with a recent toolchain will
+      automatically update the format along with the crate's depenendencies.
+    '';
+    fetchurl {
+      name = "crate-${pkg.name}-${pkg.version}.tar.gz";
+      url = "https://crates.io/api/v1/crates/${pkg.name}/${pkg.version}/download";
+      sha256 = pkg.checksum;
+    };
+
+  # Fetch and unpack a crate.
+  mkCrate = pkg:
+    let
+      gitParts = parseGit pkg.source;
+    in
+    if pkg.source == "registry+https://github.com/rust-lang/crates.io-index" then
+      let
+        crateTarball = fetchCrate pkg;
+      in
+      runCommand "${pkg.name}-${pkg.version}" { } ''
+        mkdir $out
+        tar xf "${crateTarball}" -C $out --strip-components=1
+
+        # Cargo is happy with largely empty metadata.
+        printf '{"files":{},"package":"${pkg.checksum}"}' > "$out/.cargo-checksum.json"
+      ''
+    else if gitParts != null then
+      let
+        missingHash = throw ''
+          No hash was found while vendoring the git dependency ${pkg.name}-${pkg.version}. You can add
+          a hash through the `outputHashes` argument of `importCargoLock`:
+
+          outputHashes = {
+            "${pkg.name}-${pkg.version}" = "<hash>";
+          };
+
+          If you use `buildRustPackage`, you can add this attribute to the `cargoLock`
+          attribute set.
+        '';
+        sha256 = gitShaOutputHash.${gitParts.sha} or missingHash;
+        tree = fetchgit {
+          inherit sha256;
+          inherit (gitParts) url;
+          rev = gitParts.sha; # The commit SHA is always available.
+        };
+      in
+      runCommand "${pkg.name}-${pkg.version}" { } ''
+        tree=${tree}
+
+        # If the target package is in a workspace, or if it's the top-level
+        # crate, we should find the crate path using `cargo metadata`.
+        crateCargoTOML=$(${cargo}/bin/cargo metadata --format-version 1 --no-deps --manifest-path $tree/Cargo.toml | \
+          ${jq}/bin/jq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path')
+
+        # If the repository is not a workspace the package might be in a subdirectory.
+        if [[ -z $crateCargoTOML ]]; then
+          for manifest in $(find $tree -name "Cargo.toml"); do
+            echo Looking at $manifest
+            crateCargoTOML=$(${cargo}/bin/cargo metadata --format-version 1 --no-deps --manifest-path "$manifest" | ${jq}/bin/jq -r '.packages[] | select(.name == "${pkg.name}") | .manifest_path' || :)
+            if [[ ! -z $crateCargoTOML ]]; then
+              break
+            fi
+          done
+
+          if [[ -z $crateCargoTOML ]]; then
+            >&2 echo "Cannot find path for crate '${pkg.name}-${pkg.version}' in the tree in: $tree"
+            exit 1
+          fi
+        fi
+
+        echo Found crate ${pkg.name} at $crateCargoTOML
+        tree=$(dirname $crateCargoTOML)
+
+        cp -prvd "$tree/" $out
+        chmod u+w $out
+
+        # Cargo is happy with empty metadata.
+        printf '{"files":{},"package":null}' > "$out/.cargo-checksum.json"
+
+        # Set up configuration for the vendor directory.
+        cat > $out/.cargo-config <<EOF
+        [source."${gitParts.url}"]
+        git = "${gitParts.url}"
+        ${lib.optionalString (gitParts ? type) "${gitParts.type} = \"${gitParts.value}\""}
+        replace-with = "vendored-sources"
+        EOF
+      ''
+    else throw "Cannot handle crate source: ${pkg.source}";
+
+  vendorDir = runCommand "cargo-vendor-dir"
+    (lib.optionalAttrs (lockFile == null) {
+      inherit lockFileContents;
+      passAsFile = [ "lockFileContents" ];
+    }) ''
+    mkdir -p $out/.cargo
+
+    ${
+      if lockFile != null
+      then "ln -s ${lockFile} $out/Cargo.lock"
+      else "cp $lockFileContentsPath $out/Cargo.lock"
+    }
+
+    cat > $out/.cargo/config <<EOF
+    [source.crates-io]
+    replace-with = "vendored-sources"
+
+    [source.vendored-sources]
+    directory = "cargo-vendor-dir"
+    EOF
+
+    declare -A keysSeen
+
+    for crate in ${toString depCrates}; do
+      # Link the crate directory, removing the output path hash from the destination.
+      ln -s "$crate" $out/$(basename "$crate" | cut -c 34-)
+
+      if [ -e "$crate/.cargo-config" ]; then
+        key=$(sed 's/\[source\."\(.*\)"\]/\1/; t; d' < "$crate/.cargo-config")
+        if [[ -z ''${keysSeen[$key]} ]]; then
+          keysSeen[$key]=1
+          cat "$crate/.cargo-config" >> $out/.cargo/config
+        fi
+      fi
+    done
+  '';
+in
+vendorDir

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -5,6 +5,7 @@ let
 
   mkSource = spec:
     assert spec ? type; let
+      metadata = if spec ? metadata then spec.metadata else { };
       path =
         if spec.type == "Git" then mkGitSource spec
         else if spec.type == "GitRelease" then mkGitSource spec
@@ -12,7 +13,7 @@ let
         else if spec.type == "Channel" then mkChannelSource spec
         else builtins.throw "Unknown source type ${spec.type}";
     in
-    spec // { outPath = path; };
+    spec // { outPath = path; inherit metadata; };
 
   mkGitSource = { repository, revision, url ? null, hash, ... }:
     assert repository ? type;

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -42,7 +42,7 @@ let
       sha256 = hash;
     };
 in
-if version == 3 then
+if version == 4 then
   builtins.mapAttrs (_: mkSource) data.pins
 else
   throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -25,5 +25,5 @@
       "hash": "0z09ndxvbk6w4j28lzgj0b9qqcbwrvr58c0xsm0rf0xsdipi0nwf"
     }
   },
-  "version": 3
+  "version": 4
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -69,8 +69,8 @@ impl Updatable for Pin {
         /* Prefetch an URL that looks like
          * https://releases.nixos.org/nixos/21.11/nixos-21.11.335807.df4f1f7cc3f
          */
-        let hash = nix::nix_prefetch_tarball(&version.url).await?;
+        let r = nix::nix_prefetch_tarball(&version.url).await?;
 
-        Ok(ChannelHash { hash })
+        Ok(ChannelHash { hash: r.hash })
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -65,12 +65,12 @@ impl Updatable for Pin {
         Ok(ChannelVersion { url })
     }
 
-    async fn fetch(&self, version: &ChannelVersion) -> Result<ChannelHash> {
+    async fn fetch(&self, version: &ChannelVersion) -> Result<(Option<String>, ChannelHash)> {
         /* Prefetch an URL that looks like
          * https://releases.nixos.org/nixos/21.11/nixos-21.11.335807.df4f1f7cc3f
          */
         let r = nix::nix_prefetch_tarball(&version.url).await?;
 
-        Ok(ChannelHash { hash: r.hash })
+        Ok((Some(r.store_path), ChannelHash { hash: r.hash }))
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -822,7 +822,7 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, OptionalUrlHashes {
+            (Some("/nix/store/q2pcdrxcbi51dwks482d4qb7syhf48sa-archive.tar.gz?sha=e7145078163692697b843915a665d4f41139a65c".to_string()), OptionalUrlHashes {
                 url: Some("https://gitlab.com/api/v4/projects/maxigaz%2Fgitlab-dark/repository/archive.tar.gz?sha=e7145078163692697b843915a665d4f41139a65c".parse().unwrap()),
                 hash: "0nmcr0g0cms4yx9wsgbyvxyvdlqwa9qdb8179g47rs0y04iylcsv".into(),
             })
@@ -850,7 +850,7 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, ReleasePinHashes {
+            (Some("/nix/store/gsb5ynm21sh3zhv40f00h4kl48mw7762-archive.tar.gz?ref=v1.16.0".to_string()), ReleasePinHashes {
                 revision: "d42ec2b04df9da97e465883fcd1f9a5d6e794027".into(),
                 url: Some("https://gitlab.com/api/v4/projects/maxigaz%2Fgitlab-dark/repository/archive.tar.gz?ref=v1.16.0"
                     .parse()
@@ -880,7 +880,7 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, OptionalUrlHashes {
+            (Some("/nix/store/jckwdid6lvakcjvvzm57pjggvssir9r1-archive.tar.gz?sha=bca2071b6923d45d9aabac27b3ea1e40f5fa3006".to_string()), OptionalUrlHashes {
                 url: Some("https://gitlab.gnome.org/api/v4/projects/Archive%2Fgnome-games/repository/archive.tar.gz?sha=bca2071b6923d45d9aabac27b3ea1e40f5fa3006".parse().unwrap()),
                 hash: "0pn7mdj56flvvlhm96igx8g833sslzgypfb2a4zv7lj8z3kiikmg".into(),
             })
@@ -908,7 +908,7 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, ReleasePinHashes {
+            (Some("/nix/store/ykafcnfshbnrhzyv126bs21pglqh29bq-archive.tar.gz?ref=40.0".to_string()), ReleasePinHashes {
                 revision: "2c89145d52d072a4ca5da900c2676d890bfab1ff".into(),
                 url: Some("https://gitlab.gnome.org/api/v4/projects/Archive%2Fgnome-games/repository/archive.tar.gz?ref=40.0".parse().unwrap()),
                 hash: "0pn7mdj56flvvlhm96igx8g833sslzgypfb2a4zv7lj8z3kiikmg".into(),
@@ -938,7 +938,7 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, OptionalUrlHashes {
+            (Some("/nix/store/yw30cm2p09dlhfwn8sdkhvpgn0hwgkrp-archive.tar.gz?private_token=glpat-MSsRZG1SNdJU1MzBNosV".to_string()), OptionalUrlHashes {
                 url: Some("https://gitlab.com/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=glpat-MSsRZG1SNdJU1MzBNosV".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
             })
@@ -978,7 +978,7 @@ mod test {
         // Test fetching
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, ReleasePinHashes {
+            (Some("/nix/store/yw30cm2p09dlhfwn8sdkhvpgn0hwgkrp-archive.tar.gz?private_token=glpat-MSsRZG1SNdJU1MzBNosV".to_string()), ReleasePinHashes {
                 revision: "122f7072f026644fbed6abc17c5c2ab3ae107046".into(),
                 url: Some("https://gitlab.com/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=glpat-MSsRZG1SNdJU1MzBNosV".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
@@ -1008,7 +1008,7 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, OptionalUrlHashes {
+            (Some("/nix/store/b35hifih4f3vhfkn44xwz5y01gf7s16g-archive.tar.gz?private_token=xqgHNxVNdzvMy6cDvreJ".to_string()), OptionalUrlHashes {
                 url: Some("https://git.helsinki.tools/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=xqgHNxVNdzvMy6cDvreJ".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
             })
@@ -1048,7 +1048,7 @@ mod test {
         // Test fetching
         assert_eq!(
             pin.fetch(&version).await?,
-            (None, ReleasePinHashes {
+            (Some("/nix/store/b35hifih4f3vhfkn44xwz5y01gf7s16g-archive.tar.gz?private_token=xqgHNxVNdzvMy6cDvreJ".to_string()), ReleasePinHashes {
                 revision: "122f7072f026644fbed6abc17c5c2ab3ae107046".into(),
                 url: Some("https://git.helsinki.tools/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=xqgHNxVNdzvMy6cDvreJ".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -285,11 +285,11 @@ impl Updatable for GitPin {
     async fn fetch(&self, version: &GitRevision) -> Result<OptionalUrlHashes> {
         let url = self.repository.url(&version.revision)?;
         let hash = match url.as_ref() {
-            Some(url) => nix::nix_prefetch_tarball(url).await?,
+            Some(url) => nix::nix_prefetch_tarball(url).await?.hash,
             None => {
                 nix::nix_prefetch_git(&self.repository.git_url()?, &version.revision)
                     .await?
-                    .sha256
+                    .hash
             },
         };
 
@@ -447,8 +447,8 @@ impl Updatable for GitReleasePin {
             .revision;
 
         let hash = match url.as_ref() {
-            Some(url) => nix::nix_prefetch_tarball(url).await?,
-            None => nix::nix_prefetch_git(&repo_url, &revision).await?.sha256,
+            Some(url) => nix::nix_prefetch_tarball(url).await?.hash,
+            None => nix::nix_prefetch_git(&repo_url, &revision).await?.hash,
         };
 
         Ok(ReleasePinHashes {

--- a/src/git.rs
+++ b/src/git.rs
@@ -282,18 +282,14 @@ impl Updatable for GitPin {
         Ok(GitRevision { revision: latest })
     }
 
-    async fn fetch(&self, version: &GitRevision) -> Result<OptionalUrlHashes> {
+    async fn fetch(&self, version: &GitRevision) -> Result<(Option<String>, OptionalUrlHashes)> {
         let url = self.repository.url(&version.revision)?;
-        let hash = match url.as_ref() {
-            Some(url) => nix::nix_prefetch_tarball(url).await?.hash,
-            None => {
-                nix::nix_prefetch_git(&self.repository.git_url()?, &version.revision)
-                    .await?
-                    .hash
-            },
+        let r = match url.as_ref() {
+            Some(url) => nix::nix_prefetch_tarball(url).await?,
+            None => nix::nix_prefetch_git(&self.repository.git_url()?, &version.revision).await?,
         };
 
-        Ok(OptionalUrlHashes { url, hash })
+        Ok((Some(r.store_path), OptionalUrlHashes { url, hash: r.hash }))
     }
 }
 
@@ -437,7 +433,7 @@ impl Updatable for GitReleasePin {
         Ok(GenericVersion { version: latest })
     }
 
-    async fn fetch(&self, version: &GenericVersion) -> Result<ReleasePinHashes> {
+    async fn fetch(&self, version: &GenericVersion) -> Result<(Option<String>, ReleasePinHashes)> {
         let repo_url = self.repository.git_url()?;
 
         let url = self.repository.release_url(&version.version)?;
@@ -446,16 +442,19 @@ impl Updatable for GitReleasePin {
             .await?
             .revision;
 
-        let hash = match url.as_ref() {
-            Some(url) => nix::nix_prefetch_tarball(url).await?.hash,
-            None => nix::nix_prefetch_git(&repo_url, &revision).await?.hash,
+        let r = match url.as_ref() {
+            Some(url) => nix::nix_prefetch_tarball(url).await?,
+            None => nix::nix_prefetch_git(&repo_url, &revision).await?,
         };
 
-        Ok(ReleasePinHashes {
-            url,
-            hash,
-            revision,
-        })
+        Ok((
+            Some(r.store_path),
+            ReleasePinHashes {
+                url,
+                hash: r.hash,
+                revision,
+            },
+        ))
     }
 }
 
@@ -700,10 +699,15 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            OptionalUrlHashes {
-                url: None,
-                hash: "17giznxp84h53jsm334dkp1fz6x9ff2yqfkq34ihq0ray1x3yhyd".into(),
-            }
+            (
+                Some(
+                    "/nix/store/xwc2lqbajqghcwz8h4cn80f5qh86v3xh-swing_library-1edb0a9".to_string()
+                ),
+                OptionalUrlHashes {
+                    url: None,
+                    hash: "17giznxp84h53jsm334dkp1fz6x9ff2yqfkq34ihq0ray1x3yhyd".into(),
+                }
+            )
         );
         Ok(())
     }
@@ -726,11 +730,14 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            ReleasePinHashes {
-                url: None,
-                hash: "0q06gjh6129bfs0x072xicmq0q2psnq6ckf05p1jfdxwl7jljg06".into(),
-                revision: "35be5b2b2c3431de1100996487d53134f658b866".into(),
-            }
+            (
+                Some("/nix/store/r6vb2i7538vnc9jkwg2z8blpiw898c5n-MidiOSC-35be5b2".to_owned()),
+                ReleasePinHashes {
+                    url: None,
+                    hash: "0q06gjh6129bfs0x072xicmq0q2psnq6ckf05p1jfdxwl7jljg06".into(),
+                    revision: "35be5b2b2c3431de1100996487d53134f658b866".into(),
+                }
+            )
         );
         Ok(())
     }
@@ -753,10 +760,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            OptionalUrlHashes {
+            (Some("/nix/store/zw9mpn6k0y1qjrinwqfhf3rgrfd914jb-1edb0a9cebe046cc915a218c57dbf7f40739aeee.tar.gz".to_owned()), OptionalUrlHashes {
                 url: Some("https://github.com/oliverwatkins/swing_library/archive/1edb0a9cebe046cc915a218c57dbf7f40739aeee.tar.gz".parse().unwrap()),
                 hash: "17giznxp84h53jsm334dkp1fz6x9ff2yqfkq34ihq0ray1x3yhyd".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -780,15 +787,18 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            ReleasePinHashes {
-                revision: "35be5b2b2c3431de1100996487d53134f658b866".into(),
-                url: Some(
-                    "https://api.github.com/repos/jstutters/MidiOSC/tarball/v1.1"
-                        .parse()
-                        .unwrap()
-                ),
-                hash: "0q06gjh6129bfs0x072xicmq0q2psnq6ckf05p1jfdxwl7jljg06".into(),
-            }
+            (
+                Some("/nix/store/v5lkiir4709rw858b8hq390ljzw3n2rv-v1.1".to_owned()),
+                ReleasePinHashes {
+                    revision: "35be5b2b2c3431de1100996487d53134f658b866".into(),
+                    url: Some(
+                        "https://api.github.com/repos/jstutters/MidiOSC/tarball/v1.1"
+                            .parse()
+                            .unwrap()
+                    ),
+                    hash: "0q06gjh6129bfs0x072xicmq0q2psnq6ckf05p1jfdxwl7jljg06".into(),
+                }
+            )
         );
         Ok(())
     }
@@ -812,10 +822,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            OptionalUrlHashes {
+            (None, OptionalUrlHashes {
                 url: Some("https://gitlab.com/api/v4/projects/maxigaz%2Fgitlab-dark/repository/archive.tar.gz?sha=e7145078163692697b843915a665d4f41139a65c".parse().unwrap()),
                 hash: "0nmcr0g0cms4yx9wsgbyvxyvdlqwa9qdb8179g47rs0y04iylcsv".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -840,13 +850,13 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            ReleasePinHashes {
+            (None, ReleasePinHashes {
                 revision: "d42ec2b04df9da97e465883fcd1f9a5d6e794027".into(),
                 url: Some("https://gitlab.com/api/v4/projects/maxigaz%2Fgitlab-dark/repository/archive.tar.gz?ref=v1.16.0"
                     .parse()
                     .unwrap()),
                 hash: "0nmcr0g0cms4yx9wsgbyvxyvdlqwa9qdb8179g47rs0y04iylcsv".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -870,10 +880,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            OptionalUrlHashes {
+            (None, OptionalUrlHashes {
                 url: Some("https://gitlab.gnome.org/api/v4/projects/Archive%2Fgnome-games/repository/archive.tar.gz?sha=bca2071b6923d45d9aabac27b3ea1e40f5fa3006".parse().unwrap()),
                 hash: "0pn7mdj56flvvlhm96igx8g833sslzgypfb2a4zv7lj8z3kiikmg".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -898,11 +908,11 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            ReleasePinHashes {
+            (None, ReleasePinHashes {
                 revision: "2c89145d52d072a4ca5da900c2676d890bfab1ff".into(),
                 url: Some("https://gitlab.gnome.org/api/v4/projects/Archive%2Fgnome-games/repository/archive.tar.gz?ref=40.0".parse().unwrap()),
                 hash: "0pn7mdj56flvvlhm96igx8g833sslzgypfb2a4zv7lj8z3kiikmg".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -928,10 +938,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            OptionalUrlHashes {
+            (None, OptionalUrlHashes {
                 url: Some("https://gitlab.com/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=glpat-MSsRZG1SNdJU1MzBNosV".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -968,11 +978,11 @@ mod test {
         // Test fetching
         assert_eq!(
             pin.fetch(&version).await?,
-            ReleasePinHashes {
+            (None, ReleasePinHashes {
                 revision: "122f7072f026644fbed6abc17c5c2ab3ae107046".into(),
                 url: Some("https://gitlab.com/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=glpat-MSsRZG1SNdJU1MzBNosV".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -998,10 +1008,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            OptionalUrlHashes {
+            (None, OptionalUrlHashes {
                 url: Some("https://git.helsinki.tools/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=xqgHNxVNdzvMy6cDvreJ".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
-            }
+            })
         );
         Ok(())
     }
@@ -1038,11 +1048,11 @@ mod test {
         // Test fetching
         assert_eq!(
             pin.fetch(&version).await?,
-            ReleasePinHashes {
+            (None, ReleasePinHashes {
                 revision: "122f7072f026644fbed6abc17c5c2ab3ae107046".into(),
                 url: Some("https://git.helsinki.tools/api/v4/projects/npins-test%2Fnpins-private-test/repository/archive.tar.gz?private_token=xqgHNxVNdzvMy6cDvreJ".parse().unwrap()),
                 hash: "0vdhx429r1w6yffh8gqhyj5g7zkp5dab2jgc630wllplziyfqg7z".into(),
-            }
+            })
         );
         Ok(())
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -286,7 +286,11 @@ impl Updatable for GitPin {
         let url = self.repository.url(&version.revision)?;
         let hash = match url.as_ref() {
             Some(url) => nix::nix_prefetch_tarball(url).await?,
-            None => nix::nix_prefetch_git(&self.repository.git_url()?, &version.revision).await?,
+            None => {
+                nix::nix_prefetch_git(&self.repository.git_url()?, &version.revision)
+                    .await?
+                    .sha256
+            },
         };
 
         Ok(OptionalUrlHashes { url, hash })
@@ -444,7 +448,7 @@ impl Updatable for GitReleasePin {
 
         let hash = match url.as_ref() {
             Some(url) => nix::nix_prefetch_tarball(url).await?,
-            None => nix::nix_prefetch_git(&repo_url, &revision).await?,
+            None => nix::nix_prefetch_git(&repo_url, &revision).await?.sha256,
         };
 
         Ok(ReleasePinHashes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,46 @@ pub trait Updatable:
     async fn fetch(&self, version: &Self::Version) -> Result<(Option<String>, Self::Hashes)>;
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub enum Metadata {
+    #[cfg(feature = "cargo-lock")]
+    CargoLock { json: serde_json::Value },
+}
+
+#[cfg(feature = "cargo-lock")]
+fn toml_to_json(value: toml::Value) -> serde_json::Value {
+    match value {
+        toml::Value::String(s) => s.into(),
+        toml::Value::Boolean(b) => b.into(),
+        toml::Value::Integer(i) => i.into(),
+        toml::Value::Float(f) => f.into(),
+        toml::Value::Datetime(dt) => dt.to_string().into(),
+        toml::Value::Array(a) => a.into_iter().map(toml_to_json).collect(),
+        toml::Value::Table(t) => {
+            serde_json::Value::Object(t.into_iter().map(|(k, v)| (k, toml_to_json(v))).collect())
+        },
+    }
+}
+
+impl Metadata {
+    async fn update(&mut self, path: impl AsRef<str>) -> Result<()> {
+        let path = path.as_ref();
+        match self {
+            #[cfg(feature = "cargo-lock")]
+            Metadata::CargoLock { json } => {
+                use tokio::io::AsyncReadExt;
+                let p = format!("{}/Cargo.lock", path); // FIXME: configurable, use proper path types yadayada
+                let mut fh = tokio::fs::File::open(p).await?;
+                let mut buffer = vec![];
+                fh.read_to_end(&mut buffer).await?;
+                let parsed = toml::from_slice(&buffer)?;
+                *json = toml_to_json(parsed);
+            },
+        }
+        Ok(())
+    }
+}
+
 /// Create the `Pin` type
 ///
 /// We need a type to unify over all possible way to pin a dependency. Normally, this would be done with a trait
@@ -122,6 +162,7 @@ macro_rules! mkPin {
                     version: Option<<$input_name as Updatable>::Version>,
                     #[serde(flatten)]
                     hashes: Option<<$input_name as Updatable>::Hashes>,
+		    metadata: Option<Vec<Metadata>>,
                 }
             ),*
         }
@@ -129,7 +170,9 @@ macro_rules! mkPin {
         impl Pin {
             /* Constructors */
             $(fn $lower_name(input: $input_name, version: Option<<$input_name as Updatable>::Version>) -> Self {
-                Self::$name { input, version, hashes: None }
+                Self::$name { input, version, hashes: None, metadata: Some(vec![Metadata::CargoLock {
+		    json: serde_json::Value::Null,
+		}]) }
             })*
 
             /* If an error is returned, `self` remains unchanged */
@@ -148,12 +191,31 @@ macro_rules! mkPin {
              */
             async fn fetch(&mut self) -> Result<Vec<diff::DiffEntry>> {
                 Ok(match self {
-                    $(Self::$name { input, version, hashes } => {
+                    $(Self::$name { input, version, hashes, metadata } => {
                         let version = version.as_ref()
                             .ok_or_else(|| anyhow::format_err!("No version information available, call `update` first or manually set one"))?;
                         /* Use very explicit syntax to force the correct types and get good compile errors */
                         let (path, new_hashes) = <$input_name as Updatable>::fetch(input, &version).await?;
                         let diff = hashes.insert_diffed(new_hashes);
+
+			// Handle the metadata update if there is a
+			// metadata entry, there was a diff and we got
+			// a source path back from the fetcher.
+			// FIXME: add some error logging if we can't
+			// update metadata due to missing path
+			// information despite there being a diff.
+			if !diff.is_empty() && metadata.as_ref().map(|l| !l.is_empty()).unwrap_or(false) && path.is_some() {
+			    if let (Some(m), Some(path)) = (&metadata, path) {
+				let mut new_metadata: Vec<Metadata> = vec![];
+				for mut entry in m.into_iter().cloned() {
+				    entry.update(&path).await?;
+				    new_metadata.push(entry);
+				}
+				let _ = std::mem::replace(metadata, Some(new_metadata));
+			    }
+			}
+
+			diff
                     }),*
                 })
             }
@@ -181,7 +243,8 @@ macro_rules! mkPin {
         impl std::fmt::Display for Pin {
             fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
                 match self {
-                    $(Self::$name { input, version, hashes } => {
+                    $(Self::$name { input, version, hashes, .. } => {
+			// FIXME: log metadata variants that are enabled
                         /* Concat all properties and then print them */
                         let properties = input.properties().into_iter()
                             .chain(version.iter().flat_map(Diff::properties))

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ pub trait Updatable:
     async fn update(&self, old: Option<&Self::Version>) -> Result<Self::Version>;
 
     /// Fetch hashes for a given version
-    async fn fetch(&self, version: &Self::Version) -> Result<Self::Hashes>;
+    async fn fetch(&self, version: &Self::Version) -> Result<(Option<String>, Self::Hashes)>;
 }
 
 /// Create the `Pin` type
@@ -152,8 +152,8 @@ macro_rules! mkPin {
                         let version = version.as_ref()
                             .ok_or_else(|| anyhow::format_err!("No version information available, call `update` first or manually set one"))?;
                         /* Use very explicit syntax to force the correct types and get good compile errors */
-                        let new_hashes = <$input_name as Updatable>::fetch(input, &version).await?;
-                        hashes.insert_diffed(new_hashes)
+                        let (path, new_hashes) = <$input_name as Updatable>::fetch(input, &version).await?;
+                        let diff = hashes.insert_diffed(new_hashes);
                     }),*
                 })
             }

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -108,4 +108,17 @@ mod tests {
             "/nix/store/31bxz3mxqhsinhnyvgdpdc13b86j372w-left-pad-2fca615"
         );
     }
+
+    #[tokio::test]
+    async fn test_nix_prefetch_tarball() {
+        let result = super::nix_prefetch_tarball(
+            "https://github.com/left-pad/left-pad/archive/refs/tags/v1.3.0.tar.gz",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            result,
+            "0mjvb0b51ivwi9sfkiqnjbj2y1rfblydnb0s4wdk46c7lsf1jisg"
+        )
+    }
 }

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -102,7 +102,7 @@ impl Updatable for Pin {
         Ok(GenericVersion { version })
     }
 
-    async fn fetch(&self, version: &GenericVersion) -> Result<GenericUrlHashes> {
+    async fn fetch(&self, version: &GenericVersion) -> Result<(Option<String>, GenericUrlHashes)> {
         /* Fetch the JSON metadata for a Pypi package.
          * Url template: `https://pypi.org/pypi/$pname/json`
          * JSON schema (as in the returned value): https://warehouse.pypa.io/api-reference/json.html
@@ -131,10 +131,13 @@ impl Updatable for Pin {
             )
         })?;
 
-        Ok(GenericUrlHashes {
-            hash,
-            url: latest_source.url.parse()?,
-        })
+        Ok((
+            None,
+            GenericUrlHashes {
+                hash,
+                url: latest_source.url.parse()?,
+            },
+        ))
     }
 }
 
@@ -189,10 +192,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            GenericUrlHashes {
+            (None, GenericUrlHashes {
                 hash: "3953b158b7b690642d68cd6beb1d59f6e10526f2ee10a6fb4636a913cc95e718".into(),
                 url: "https://files.pythonhosted.org/packages/d1/d5/0c270c22d61ff6b883d0f24956f13e904b131b5ac2829e0af1cda99d70b1/gaiatest-0.34.tar.gz".parse().unwrap(),
-            }
+            })
         );
         Ok(())
     }
@@ -215,10 +218,10 @@ mod test {
         );
         assert_eq!(
             pin.fetch(&version).await?,
-            GenericUrlHashes {
+            (None, GenericUrlHashes {
                 hash: "39d09c6627255fcf39c938937995665b6377799c4fa141f6b481bcb5e6a688ac".into(),
                 url: "https://files.pythonhosted.org/packages/fd/75/6e72889c3b154a179040b94963a50901966ff30b68600271df374b2ded7a/streamlit-0.89.0.tar.gz".parse().unwrap(),
-            }
+            })
         );
         Ok(())
     }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -277,27 +277,31 @@ mod test {
             pins,
             NixPins {
                 pins: btreemap![
-                    "nixos-mailserver".into() => Pin::Git {
-                        input: git::GitPin::git("https://gitlab.com/simple-nixos-mailserver/nixos-mailserver.git".parse().unwrap(), "nixos-21.11".into()),
-                        version: Some(git::GitRevision { revision: "6e3a7b2ea6f0d68b82027b988aa25d3423787303".into() }),
-                        hashes: Some(git::OptionalUrlHashes { url: None, hash: "1i56llz037x416bw698v8j6arvv622qc0vsycd20lx3yx8n77n44".into() } ),
-                    },
-                    "nixpkgs".into() => Pin::Git {
-                        input: git::GitPin::github("nixos", "nixpkgs", "nixpkgs-unstable".into()),
-                        version: Some(git::GitRevision { revision: "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2".into() }),
-                        hashes: Some(git::OptionalUrlHashes { url: Some("https://github.com/nixos/nixpkgs/archive/5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2.tar.gz".parse().unwrap()), hash: "1r74afnalgcbpv7b9sbdfbnx1kfj0kp1yfa60bbbv27n36vqdhbb".into() }),
-                    },
-                    "streamlit".into() => Pin::PyPi {
-                        input: pypi::Pin { name: "streamlit".into(), version_upper_bound: None },
-                        version: Some(GenericVersion { version: "1.3.1".into() }),
-                        hashes: Some(GenericUrlHashes { url: "https://files.pythonhosted.org/packages/c3/9d/ac871992617220442832af12c3808716f4349ab05ff939d695fe8b542f00/streamlit-1.3.1.tar.gz".parse().unwrap(), hash: "adec7935c9cf774b9115b2456cf2f48c4f49b9f67159a97db0fe228357c1afdf".into() } )
-                    },
-                    "youtube-dl".into() => Pin::GitRelease {
-                        input: git::GitReleasePin::github("ytdl-org", "youtube-dl", false, None),
-                        version: Some(GenericVersion { version: "youtube-dl 2021.12.17".into() }),
-                        hashes: None,
-                    }
-                ],
+                        "nixos-mailserver".into() => Pin::Git {
+                            input: git::GitPin::git("https://gitlab.com/simple-nixos-mailserver/nixos-mailserver.git".parse().unwrap(), "nixos-21.11".into()),
+                            version: Some(git::GitRevision { revision: "6e3a7b2ea6f0d68b82027b988aa25d3423787303".into() }),
+                            hashes: Some(git::OptionalUrlHashes { url: None, hash: "1i56llz037x416bw698v8j6arvv622qc0vsycd20lx3yx8n77n44".into() } ),
+                metadata: None,
+                        },
+                        "nixpkgs".into() => Pin::Git {
+                            input: git::GitPin::github("nixos", "nixpkgs", "nixpkgs-unstable".into()),
+                            version: Some(git::GitRevision { revision: "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2".into() }),
+                            hashes: Some(git::OptionalUrlHashes { url: Some("https://github.com/nixos/nixpkgs/archive/5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2.tar.gz".parse().unwrap()), hash: "1r74afnalgcbpv7b9sbdfbnx1kfj0kp1yfa60bbbv27n36vqdhbb".into() }),
+                metadata: None,
+                        },
+                        "streamlit".into() => Pin::PyPi {
+                            input: pypi::Pin { name: "streamlit".into(), version_upper_bound: None },
+                            version: Some(GenericVersion { version: "1.3.1".into() }),
+                            hashes: Some(GenericUrlHashes { url: "https://files.pythonhosted.org/packages/c3/9d/ac871992617220442832af12c3808716f4349ab05ff939d695fe8b542f00/streamlit-1.3.1.tar.gz".parse().unwrap(), hash: "adec7935c9cf774b9115b2456cf2f48c4f49b9f67159a97db0fe228357c1afdf".into() } ),
+                metadata: None,
+                        },
+                        "youtube-dl".into() => Pin::GitRelease {
+                            input: git::GitReleasePin::github("ytdl-org", "youtube-dl", false, None),
+                            version: Some(GenericVersion { version: "youtube-dl 2021.12.17".into() }),
+                            hashes: None,
+                metadata: None,
+                        }
+                    ],
             }
         );
     }

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Map, Value};
 
 /// The current format version
-pub const LATEST: u64 = 3;
+pub const LATEST: u64 = 4;
 
 /// Custom manual deserialize wrapper that checks the version
 pub fn from_value_versioned(value: Value) -> Result<NixPins> {

--- a/test.nix
+++ b/test.nix
@@ -40,8 +40,8 @@ let
       git tag '${tag}'
       git checkout -B 'master' # TODO remove this and tests fail (:
 
-      ${extraCommands}
       '') tags}
+      ${extraCommands}
 
       git update-server-info
       cp -r .git $out
@@ -180,28 +180,51 @@ in
     name = "cargo-lock-self";
     gitRepo = mkGitRepo {
       extraCommands = ''
-        cp -rv ${./Cargo.lock} ${./Cargo.toml} ${./npins} ${./src}  .
+        cp -rv ${./npins} npins
+        cp -rv ${./src} src
+        cp -rv ${./Cargo.lock} Cargo.lock
+        cp -rv ${./Cargo.toml} Cargo.toml
         git add Cargo.lock Cargo.toml npins src
+        ls -la
         git commit -m "add npins"
       '';
     };
-    commands = ''
-      npins init --bare
-      npins add git http://localhost:8000/foo
-
-      cat <<EOF > cargo-lock-metadata.nix
+    commands =
       let
-        pkgs = import ${pkgs.path} {};
-        pins = import ./npins;
-      in pkgs.rustPlatform.buildRustPackage {
-        pname = "npins";
-        version = pins.npins.revision;
-        cargoLock.lockFileContents = builtins.toJSON pins.npins.metadata.cargoLock;
-        src = pins.nins;
-      }
-      EOF
+        patchedNixpkgs = pkgs.runCommand "patched-nixpkgs"
+          {
+            pkgs = pkgs.path;
+          } ''
+          cp -rv $pkgs $out
+          chmod +rw -R $out
+          cp ${./import-cargo-lock.nix} $out/pkgs/build-support/rust/import-cargo-lock.nix
+        '';
+      in
+      ''
+        npins init --bare
+        npins add --name npins git http://localhost:8000/foo -b master
 
-      nix-instantiate --eval cargo-lock-metadata.nix 
-    '';
+        cat <<EOF > cargo-lock-metadata.nix
+        let
+          pkgs = import ${patchedNixpkgs} {
+               overlays = [
+                  (self: super: {
+                    importCargoLock = self.callPackage ${./import-cargo-lock.nix} { };
+                  })
+               ];
+          };
+          pins = import ./npins;
+        in toString (pkgs.rustPlatform.buildRustPackage {
+          pname = "npins";
+          version = pins.npins.revision;
+          cargoLock.lockFileData = (builtins.elemAt pins.npins.metadata 0).CargoLock.json;
+          src = pins.npins;
+        })
+        EOF
+
+        cat npins/sources.json
+
+        nix-instantiate --eval cargo-lock-metadata.nix
+      '';
   };
 }


### PR DESCRIPTION
HACK: introduce metadata for newly added pins

This is an experiment that includes Cargo.lock metadata in our
lockfiles for all added pins. The idea is outlined in [an issue] and
this is just a quick hack to get this going.

Currently the GitLab tests are failing as I didn't bother fixing them
given that they are currently being changed.

To test this initialize a new bare npins folder:

$ npins -d /tmp/foo init --bar

Then you can add a rust project (e.g. npins):

$ npins -d /tmp/foo add github andir npins

Now you should have a regular pin entry but also the JSON equivalent
of the Cargo.lock (TOML) file in a sub attribute.

$ less /tmp/foo/sources.json

This in itself isn't particular helpful yet but with a bit more
work (on our Nix shim and a variant of import-cargo) we can implement
the vision of the linked issue experimentally.

Open tasks:

 * [ ] Is there a better way to handle the prefetched source path?
 * [ ] Add some CLI options to opting into some kind of metadata
       inclusion, right now we just include it unconditionally.
 * [ ] Ergonomics, ergonomisc and ergonomics of the feature. It must
       not suck!
