### PR TITLE
Allow initializing pins without creating the default.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ USAGE:
     npins init [FLAGS] [OPTIONS]
 
 FLAGS:
-        --bare    Don't add an initial `nixpkgs` entry
-    -h, --help    Prints help information
+        --bare              Don't add an initial `nixpkgs` entry
+    -h, --help              Prints help information
+        --no-default-nix    Don't add the initial default.nix
 
 OPTIONS:
     -d, --directory <folder>    Base folder for sources.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -356,6 +356,10 @@ pub struct InitOpts {
     /// Don't add an initial `nixpkgs` entry
     #[structopt(long)]
     pub bare: bool,
+
+    /// Don't add the initial default.nix
+    #[structopt(long)]
+    pub no_default_nix: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -447,10 +451,13 @@ impl Opts {
             log::info!("Creating `{}` directory", self.folder.display());
             std::fs::create_dir(&self.folder).context("Failed to create npins folder")?;
         }
-        log::info!("Writing default.nix");
-        let p = self.folder.join("default.nix");
-        let mut fh = std::fs::File::create(&p).context("Failed to create npins default.nix")?;
-        fh.write_all(default_nix)?;
+
+        if !o.no_default_nix {
+            log::info!("Writing default.nix");
+            let p = self.folder.join("default.nix");
+            let mut fh = std::fs::File::create(&p).context("Failed to create npins default.nix")?;
+            fh.write_all(default_nix)?;
+        }
 
         // Only create the pins if the file isn't there yet
         if self.folder.join("sources.json").exists() {

--- a/test.nix
+++ b/test.nix
@@ -110,6 +110,20 @@ let
   '';
 in
 {
+  noDefaultNix = mkGitTest {
+    name = "add-dry-run";
+    inherit gitRepo;
+    commands = ''
+      npins init --bare --no-default-nix
+      npins add -n git http://localhost:8000/foo -b test-branch
+
+      test -e npins/default.nix && exit 1
+      V=$(jq -r .pins npins/sources.json)
+      [[ "$V" = "{}" ]]
+    '';
+  };
+
+
   addDryRun = mkGitTest {
     name = "add-dry-run";
     inherit gitRepo;


### PR DESCRIPTION
This allows usage of npins for locking-only purposes where the consumer might have a copy of a default.nix already or where they provide their own implementation (and will fix breakage caused by newer versions of npins).