### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ nix-shell -p npins
 You can easily get a nightly if you want to (requires newstyle Nix commands):
 
 ```sh
-nix run -f https://github.com/andir/npins/archive/master.tar.gz
+nix shell -f https://github.com/andir/npins/archive/master.tar.gz
 ```
 
 You could also install it to your profile using `nix-env` (not recommended, but might be useful for bootstrapping):

--- a/README.md.in
+++ b/README.md.in
@@ -38,7 +38,7 @@ nix-shell -p npins
 You can easily get a nightly if you want to (requires newstyle Nix commands):
 
 ```sh
-nix run -f https://github.com/andir/npins/archive/master.tar.gz
+nix shell -f https://github.com/andir/npins/archive/master.tar.gz
 ```
 
 You could also install it to your profile using `nix-env` (not recommended, but might be useful for bootstrapping):


### PR DESCRIPTION
`nix run` is the outdated version, as it is meant for running "apps", not creating a shell for running programs. Accordingly, `nix run -c` was replaced upstream with `nix shell -c`.

Hence update README to reflect this.