### PR TITLE
Prepare version 0.2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: nixbuild/nix-quick-install-action@v6
-        with:
-          nix_conf: |
-             extra-substituters = https://cache.h4ck.space/
-             trusted-public-keys = zeta:9zm3cHRlqz3T9HnRsodtQGGqHOLDAiB+8d0kOKnFI0M= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-      - uses: nixbuild/nixbuild-action@v8
-        with:
-          nixbuild_ssh_key: ${{ secrets.nixbuild_ssh_key }}
-        if: ${{ github.ref_name == 'master' }}
+      - uses: actions/checkout@v4.1.3
+      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Build
         run: nix-build
       - name: Run pre-commit hooks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "npins"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,19 +37,19 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -98,9 +98,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
@@ -110,9 +110,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -153,9 +153,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -639,18 +639,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -810,29 +810,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "indexmap",
  "itoa",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1030,7 +1030,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1187,7 +1187,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -1221,7 +1221,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1294,7 +1294,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1314,17 +1314,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -1335,9 +1336,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1347,9 +1348,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1359,9 +1360,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1371,9 +1378,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1383,9 +1390,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1395,9 +1402,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1407,9 +1414,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "npins"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "EUPL-1.2"
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You may also use attributes from the JSON file, they are exposed 1:1. For exampl
 
 ```console
 $ npins help
-npins 0.2.2
+npins 0.2.3
 
 USAGE:
     npins [OPTIONS] <SUBCOMMAND>
@@ -138,7 +138,7 @@ This will create an `npins` folder with a `default.nix` and `sources.json` withi
 
 ```console
 $ npins help init
-npins-init 0.2.2
+npins-init 0.2.3
 Intializes the npins directory. Running this multiple times will restore/upgrade the `default.nix` and never touch your
 sources.json
 
@@ -169,7 +169,7 @@ Note that the import functionality is minimal and only preserves the necessary i
 
 ```console
 $ npins help import-niv
-npins-import-niv 0.2.2
+npins-import-niv 0.2.3
 Try to import entries from Niv
 
 USAGE:
@@ -209,7 +209,7 @@ Depending on what kind of dependency you are adding, different arguments must be
 
 ```console
 $ npins help add
-npins-add 0.2.2
+npins-add 0.2.3
 Adds a new pin entry
 
 USAGE:
@@ -237,7 +237,7 @@ SUBCOMMANDS:
 
 ```console
 $ npins help remove
-npins-remove 0.2.2
+npins-remove 0.2.3
 Removes one pin entry
 
 USAGE:
@@ -260,7 +260,7 @@ This will print the currently pinned dependencies in a human readable format. Th
 
 ```console
 $ npins help show
-npins-show 0.2.2
+npins-show 0.2.3
 Lists the current pin entries
 
 USAGE:
@@ -280,7 +280,7 @@ You can decide to update only selected dependencies, or all at once. For some pi
 
 ```console
 $ npins help update
-npins-update 0.2.2
+npins-update 0.2.3
 Updates all or the given pin to the latest version
 
 USAGE:
@@ -307,7 +307,7 @@ To ensure compatibility across releases, the `npins/sources.json` and `npins/def
 
 ```console
 $ npins help upgrade
-npins-upgrade 0.2.2
+npins-upgrade 0.2.3
 Upgrade the sources.json and default.nix to the latest format version. This may occasionally break Nix evaluation!
 
 USAGE:

--- a/npins.nix
+++ b/npins.nix
@@ -36,8 +36,7 @@ let
         let
           suffix = lib.removePrefix baseDir path;
         in
-        _:
-        lib.any (r: builtins.match r suffix != null) expressions;
+        _: lib.any (r: builtins.match r suffix != null) expressions;
       name = "source";
     };
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -8,9 +8,9 @@
         "repo": "nixfmt"
       },
       "branch": "rfc101-style",
-      "revision": "1eff7a84ac82fbebb5f586244f1c80e1fcc4f494",
-      "url": "https://github.com/piegamesde/nixfmt/archive/1eff7a84ac82fbebb5f586244f1c80e1fcc4f494.tar.gz",
-      "hash": "1pg876sr58h7v087kbjsnfr4pzvqpwzibl06w2468qs1sywmd283"
+      "revision": "8d13b593fa8d8d6e5075f541f3231222a08e84df",
+      "url": "https://github.com/piegamesde/nixfmt/archive/8d13b593fa8d8d6e5075f541f3231222a08e84df.tar.gz",
+      "hash": "1blpqs2ifw10xvfpfk77p1bq35gzgssng2m8wqw0kqydcz7fzm8y"
     },
     "nixpkgs": {
       "type": "Git",
@@ -20,9 +20,9 @@
         "repo": "nixpkgs"
       },
       "branch": "nixpkgs-unstable",
-      "revision": "46688f8eb5cd6f1298d873d4d2b9cf245e09e88e",
-      "url": "https://github.com/nixos/nixpkgs/archive/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e.tar.gz",
-      "hash": "1qk28amvb3r766z0zs2wrbm33ifq6rmpcp0p5c86d9zb4l33nvfw"
+      "revision": "92d295f588631b0db2da509f381b4fb1e74173c5",
+      "url": "https://github.com/nixos/nixpkgs/archive/92d295f588631b0db2da509f381b4fb1e74173c5.tar.gz",
+      "hash": "162w28y4i5c8g5qhjvs827qxphf2a8n4c8fwhcywzl1j1a35h2im"
     },
     "pre-commit-hooks.nix": {
       "type": "Git",
@@ -32,9 +32,9 @@
         "repo": "pre-commit-hooks.nix"
       },
       "branch": "master",
-      "revision": "4f883a76282bc28eb952570afc3d8a1bf6f481d7",
-      "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/4f883a76282bc28eb952570afc3d8a1bf6f481d7.tar.gz",
-      "hash": "1ahkfgz39jglhs5svmmm04hbk5wyq2ph620wa7qqb9d8594639x1"
+      "revision": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
+      "url": "https://github.com/cachix/pre-commit-hooks.nix/archive/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8.tar.gz",
+      "hash": "0xibcl3546fqv9g2wmjv6350glp61ld3m8n5yqjx0y5dn73apj4w"
     }
   },
   "version": 3

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,11 @@ let
   pkgs = import pins.nixpkgs {
     inherit system;
     overlays = [
-      (self: super: { nixfmt = super.nixfmt.overrideAttrs (old: { src = pins.nixfmt; }); })
+      (self: super: {
+        nixfmt = super.nixfmt.overrideAttrs (old: {
+          src = pins.nixfmt;
+        });
+      })
     ];
   };
   inherit (pkgs) stdenv lib;

--- a/test.nix
+++ b/test.nix
@@ -33,14 +33,12 @@ let
       git add test.txt
       git commit -v -m "init"
 
-      ${pkgs.lib.concatMapStringsSep "\n"
-        (tag: ''
-          echo '${tag}' > test.txt
-          git add test.txt
-          git commit -v -m 'commit for tag ${tag}'
-          git tag '${tag}'
-        '')
-        tags}
+      ${pkgs.lib.concatMapStringsSep "\n" (tag: ''
+        echo '${tag}' > test.txt
+        git add test.txt
+        git commit -v -m 'commit for tag ${tag}'
+        git tag '${tag}'
+      '') tags}
 
       git checkout -B '${branchName}' # TODO remove this and tests fail (:
       ${extraCommands}


### PR DESCRIPTION
Mostly updates to our dependencies and documentation for the `--name`
argument.

Changes since last release:
 * https://github.com/andir/npins/commit/1de2ff57fdc4a7c446711d6273fc0230c8967420 update nix dependencies
 * https://github.com/andir/npins/commit/957ff6692ead24a8a2c8e117fd7ea3cccf993920 Switch to nixfmt
 * https://github.com/andir/npins/commit/46036c2a647e48b4f87905dace6fe6578c4474ed Bump h2 from 0.3.21 to 0.3.24
 * https://github.com/andir/npins/commit/0ec7afa85010d62a55d9288196524640d6362e1b Bump mio from 0.8.8 to 0.8.11
 * https://github.com/andir/npins/commit/1e1495a5beeeb328f26dc1c34077969ff42e1546 Document the `--name` option (https://github.com/andir/npins/pull/65)
 * https://github.com/andir/npins/commit/6a830f1321b1813630f052183a5ca43a66c97314 Bump h2 from 0.3.24 to 0.3.26
 * https://github.com/andir/npins/commit/9a88ce1a40ad7a2274e2ebe2f626e06b68b891f5 Update env_logger
 * https://github.com/andir/npins/commit/377728065a3b3a8256aa96f4313a35fb30f6eb6c Update dependencies
 * https://github.com/andir/npins/commit/0bdf1d4a1f73e51184c93944d6226404e4263c0c Bump rustls from 0.21.10 to 0.21.11
 * https://github.com/andir/npins/commit/1af47fef51f9ad573d520e0ea116382d8f604aaf Update all dependencies