### PR TITLE
A rough import-flake sub command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,17 @@ OPTIONS:
                                 [default: npins]
 
 SUBCOMMANDS:
-    add           Adds a new pin entry
-    help          Prints this message or the help of the given subcommand(s)
-    import-niv    Try to import entries from Niv
-    init          Intializes the npins directory. Running this multiple times will restore/upgrade the `default.nix`
-                  and never touch your sources.json
-    remove        Removes one pin entry
-    show          Lists the current pin entries
-    update        Updates all or the given pin to the latest version
-    upgrade       Upgrade the sources.json and default.nix to the latest format version. This may occasionally break
-                  Nix evaluation!
+    add             Adds a new pin entry
+    help            Prints this message or the help of the given subcommand(s)
+    import-flake    Try to import entries from flake.lock
+    import-niv      Try to import entries from Niv
+    init            Intializes the npins directory. Running this multiple times will restore/upgrade the
+                    `default.nix` and never touch your sources.json
+    remove          Removes one pin entry
+    show            Lists the current pin entries
+    update          Updates all or the given pin to the latest version
+    upgrade         Upgrade the sources.json and default.nix to the latest format version. This may occasionally
+                    break Nix evaluation!
 ```
 
 ### Initialization

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -703,10 +703,13 @@ impl Opts {
             import(name, None, &mut pins, &niv).await?;
         } else {
             for (name, pin) in niv.iter() {
-                println!("Importing {}", name);
+                log::info!("Importing {}", name);
                 if let Err(err) = import(name, Some(pin), &mut pins, &niv).await {
                     log::error!("Failed to import pin '{}'", name);
                     log::error!("{}", err);
+                    err.chain()
+                        .skip(1)
+                        .for_each(|cause| log::error!("\t{}", cause));
                 }
             }
         }
@@ -798,10 +801,13 @@ impl Opts {
             .await?;
         } else {
             for (name, input_name) in inputs.iter() {
-                println!("Importing {}", name);
-                if let Err(err) = import(input_name, &mut pins, &nodes).await {
+                log::info!("Importing {}", name);
+                if let Err(err) = import(input_name, &mut pins, nodes).await {
                     log::error!("Failed to import pin '{}'", name);
                     log::error!("{}", err);
+                    err.chain()
+                        .skip(1)
+                        .for_each(|cause| log::error!("\t{}", cause));
                 }
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -793,7 +793,7 @@ impl Opts {
                     .get(name)
                     .context(format!("flake input {name} not found"))?,
                 &mut pins,
-                &nodes,
+                nodes,
             )
             .await?;
         } else {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -378,6 +378,15 @@ pub struct ImportOpts {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct ImportFlakeOpts {
+    #[structopt(default_value = "flake.lock", parse(from_os_str))]
+    pub path: PathBuf,
+    /// Only import one entry from the flake
+    #[structopt(short, long)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
 pub enum Command {
     /// Intializes the npins directory. Running this multiple times will restore/upgrade the
     /// `default.nix` and never touch your sources.json.
@@ -400,6 +409,9 @@ pub enum Command {
 
     /// Try to import entries from Niv
     ImportNiv(ImportOpts),
+
+    /// Try to import entries from flake.lock
+    ImportFlake(ImportFlakeOpts),
 }
 
 use structopt::clap::AppSettings;
@@ -704,6 +716,101 @@ impl Opts {
         Ok(())
     }
 
+    async fn import_flake(&self, o: &ImportFlakeOpts) -> Result<()> {
+        let mut pins = self.read_pins()?;
+
+        let flake: serde_json::Value =
+            serde_json::from_reader(std::fs::File::open(&o.path).context(anyhow::format_err!(
+                "Could not open flake.lock at '{}'",
+                o.path.canonicalize().unwrap_or_else(|_| o.path.clone()).display()
+            ))?)
+            .context("Nix lock file is not a valid JSON object")?;
+        log::info!("Note that all the imported entries will be updated so they won't necessarily point to the same commits as before!");
+
+        let nodes: &serde_json::Map<String, serde_json::Value> = flake
+            .get("nodes")
+            .context("flake.lock missing key `nodes`")?
+            .as_object()
+            .context("`nodes` key does not contain an object")?;
+
+        let root_name = flake
+            .get("root")
+            .context("missing `root` key")?
+            .as_str()
+            .context("`root` key of flake lockfile is not a string")?;
+        let root = nodes
+            .get(root_name)
+            .context("flake.lock missing key `root`")?
+            .get("inputs")
+            .context("`root` key missing `inputs` key")?
+            .as_object()
+            .context("`root` key is not an object")?;
+
+        let inputs: BTreeMap<String, String> = root
+            .into_iter()
+            .map(|(key, value)| Some((key.to_string(), value.as_str()?.to_string())))
+            .collect::<Option<_>>()
+            .context(format!(
+                "root flake input `{root_name}` had unexpected format and could not be read"
+            ))?;
+
+        async fn import(
+            name: &str,
+            npins: &mut NixPins,
+            nodes: &serde_json::Map<String, serde_json::Value>,
+        ) -> Result<()> {
+            let pin = nodes
+                .get(name)
+                .ok_or_else(|| anyhow::format_err!("Pin '{}' not found in flake.lock", name))?;
+            anyhow::ensure!(
+                !npins.pins.contains_key(name),
+                "Pin '{}' exists in both files, this is a collision. Please delete the entry in one of the files.",
+                name
+            );
+
+            let pin: flake::FlakePin = serde_json::from_value(pin.clone())
+                .context("Pin is either invalid, or we don't support it")?;
+
+            if pin.is_indirect() {
+                log::info!("skipping indirect input {}", name);
+                return Ok(());
+            }
+
+            let mut pin: Pin = pin
+                .try_into()
+                .context("Could not convert pin to npins format")?;
+
+            pin.update().await?;
+            pin.fetch().await.context("Failed to update the pin")?;
+            npins.pins.insert(name.to_string(), pin);
+
+            Ok(())
+        }
+
+        if let Some(name) = &o.name {
+            import(
+                inputs
+                    .get(name)
+                    .context(format!("flake input {name} not found"))?,
+                &mut pins,
+                &nodes,
+            )
+            .await?;
+        } else {
+            for (name, input_name) in inputs.iter() {
+                println!("Importing {}", name);
+                if let Err(err) = import(input_name, &mut pins, &nodes).await {
+                    log::error!("Failed to import pin '{}'", name);
+                    log::error!("{}", err);
+                }
+            }
+        }
+
+        self.write_pins(&pins)?;
+        log::info!("Done.");
+        Ok(())
+    }
+
     pub async fn run(&self) -> Result<()> {
         match &self.command {
             Command::Init(o) => self.init(o).await?,
@@ -713,6 +820,7 @@ impl Opts {
             Command::Upgrade => self.upgrade()?,
             Command::Remove(r) => self.remove(r)?,
             Command::ImportNiv(o) => self.import_niv(o).await?,
+            Command::ImportFlake(o) => self.import_flake(o).await?,
         };
 
         Ok(())

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -1,0 +1,122 @@
+//! Convert+Import Nix flake lock files
+
+use crate::*;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use url::Url;
+
+/// Pin entry from a nix flake's lock file
+///
+/// Flake locks have a two-part structure: the input's specification, and the
+/// actual pin itself (under `locked`). We need aspects of both, but ignore the
+/// other attributes (e.g. whether an input is a flake or not)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlakePin {
+    locked: FlakeLocked,
+    original: FlakeOriginal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum FlakeType {
+    Gitlab,
+    Github,
+    Git,
+    Path,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlakeLocked {
+    /// repository owner on GitHub, or repository prefix on GitLab
+    owner: Option<String>,
+    /// repository name on GitHub and GitLab
+    repo: Option<String>,
+    /// the url of a generic git input
+    url: Option<Url>,
+    #[serde(rename = "type")]
+    type_: FlakeType,
+    /// git ref in all git input types
+    #[serde(rename = "ref")]
+    ref_: Option<String>,
+    /// the input's hash. not used, but kept here in case we want to implement
+    /// also importing the pins themselves
+    #[serde(rename = "narHash")]
+    nar_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlakeOriginal {
+    /// git ref in git input types where a branch is referred to, but locked
+    #[serde(rename = "ref")]
+    ref_: Option<String>,
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+impl FlakePin {
+    pub fn is_indirect(&self) -> bool {
+        self.original.type_ == "indirect"
+    }
+}
+
+impl TryFrom<FlakePin> for Pin {
+    type Error = anyhow::Error;
+
+    fn try_from(flake: FlakePin) -> Result<Self> {
+        use FlakeType::*;
+
+        // "indirect" inputs (i.e. dependencies of flake dependencies) are
+        // not supported for now
+        assert_ne!(flake.original.type_, "indirect");
+
+        Ok(match flake.locked.type_ {
+            Gitlab => git::GitPin::gitlab(
+                format!(
+                    "{}/{}",
+                    flake
+                        .locked
+                        .owner
+                        .context("missing field owner in gitlab flake input")?,
+                    flake
+                        .locked
+                        .repo
+                        .context("missing field repo in gitlab flake input")?
+                ),
+                // I am not sure if there is any documentation on this format,
+                // but if no ref is present, it appears always `master` is meant
+                flake.original.ref_.unwrap_or_else(|| "master".to_owned()),
+                None,
+                None,
+            )
+            .into(),
+            Github => git::GitPin::github(
+                flake
+                    .locked
+                    .owner
+                    .context("missing owner field in github flake input")?,
+                flake
+                    .locked
+                    .repo
+                    .context("missing field repo in github flake input")?,
+                flake.original.ref_.unwrap_or_else(|| "master".to_owned()),
+            )
+            .into(),
+            Git => {
+                let mut ref_ = flake
+                    .locked
+                    .ref_
+                    .context("missing ref on git flake input")?;
+                if let Some(shortened) = ref_.strip_prefix("refs/heads/") {
+                    ref_ = shortened.to_string();
+                }
+                git::GitPin::git(
+                    flake.locked.url.context("missing url on git flake input")?,
+                    ref_,
+                )
+                .into()
+            },
+            Path => anyhow::bail!("Path inputs are currently not supported by npins."),
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use structopt::StructOpt;
 pub mod channel;
 pub mod cli;
 pub mod diff;
+pub mod flake;
 pub mod git;
 pub mod niv;
 pub mod nix;

--- a/test.nix
+++ b/test.nix
@@ -236,5 +236,34 @@ in
       branch = mkPrefetchGitTest "branch" "--branch test-branch";
       tag = mkPrefetchGitTest "tag" "--at v0.2";
       hash = mkPrefetchGitTest "hash" "--branch test-branch --at 9ba40d123c3e6adb35c99ad04fd9de6bcdc1c9d5";
+
+      importGitFromFlake =
+        let
+          flake = pkgs.writeText "flake.nix" ''
+            {
+              inputs.foo.url = "git+http://localhost:8000/foo?ref=test-branch";
+              inputs.foo.flake = false;
+              outputs = _: {};
+            }
+          '';
+        in
+        mkGitTest {
+          name = "from-flake-import-git";
+          inherit gitRepo;
+          commands = ''
+            cp ${flake} flake.nix
+            nix --extra-experimental-features flakes --extra-experimental-features nix-command flake update
+
+            npins init --bare
+            npins import-flake
+            git ls-remote http://localhost:8000/foo
+            nix-instantiate --eval npins -A foo.outPath
+
+            cat npins/sources.json
+
+            V=$(jq -r .pins.foo.branch npins/sources.json)
+            [[ "$V" = "test-branch" ]]
+          '';
+        };
     };
 }


### PR DESCRIPTION
i.e. a thing analogous to `npins import-niv`:

~~~
> npins import-flake
[INFO ] Note that all the imported entries will be updated so they won't necessarily point to the same commits as before!
Importing nixos-mailserver
Importing nixpkgs
[INFO ] skipping indirect input nixpkgs_2
~~~

I wrote it since, recently, I have once again become somewhat annoyed at my own usage of nix flakes (among many other things). So here I am. Thanks for all your work! (I used niv a couple years ago, and it feels nice to have something like it again — although of course niv also still exists).

While moving my own configs, I decided I didn't feel like moving all my old inputs across by hand, so I wrote this instead.

Unfortunately, this does mean it has some limitations. While I've modelled it on the existing niv importer, it covers not much more than exactly what I needed. So it is not very complete; it supports only git imports (github, gitlab, generic git), but flakes can also have many other types of input. On the other hand, as this is already (I think?) the entire common subset of input types between npins and flakes, this might be the best we can do?

Like the niv importer, there's no effort to keep the pins/hashes (although they are read & it should probably be possible to keep them — but I decided I didn't mind the dependency bump, so I've not looked into this further).

It is probably also generally very brittle — as far as I could see, there is not much documentation on the actual format used in flake lock files (the [closest in the manual are some examples](https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake#lock-files), which further appear to be out of date, or at least noticably differ from how my `flake.lock`s look like). So while it has worked fine for me on the couple flakes I tried it on so far, it might very well break on another.

Finally, probably the biggest problem is how to document this, because while automatically transforming the lockfile helps a fair bit, a transition from a nix flakes-based config to an npins-versioned one is still somewhat bumpy (I now have various little hacks and shims in my nix expressions so I can still use dependencies which do not expose a non-flaky interface), and I don't see how it can really be automated more than this. Particularly, the importer skips indirect dependencies (it could also keep them — but then what would it do with them?).
