### PR TITLE
Fix the pre-commit-hooks' files entry for the README

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,7 @@ let
       rustfmt.enable = true;
       update-readme = {
         enable = true;
-        files = "((readme\\.pre\\.md|readme\\.post\\.md|^readme\\.nix|Cargo\\.toml)|\\.rs)$";
+        files = "((^README\\.md\\.in|^README\\.md|^readme\\.nix|^Cargo\\.toml)|\\.rs)$";
         entry = toString (
           pkgs.writeShellScript "update-readme" ''
             ${pkgs.nix}/bin/nix-build ${toString ./readme.nix} -o readme && cp readme README.md


### PR DESCRIPTION
We've migrated to a different style of README file naming very early during the projects life. Unfortunately the files pattern wasn't updated so changes the our current README.md.in file weren't caught as were the changes to the bare README.md.

This is now fixed.