### PR TITLE
Support filtering releases & tags by prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,35 @@ SUBCOMMANDS:
     pypi       Track a package on PyPi
 ```
 
+There are several options for tracking git branches, releases and tags:
+
+```console
+$ npins help add git
+npins-add-git 0.2.3
+Track a git repository
+
+USAGE:
+    npins add git [FLAGS] [OPTIONS] <url>
+
+FLAGS:
+    -h, --help            Prints help information
+        --pre-releases    Also track pre-releases. Conflicts with the --branch option
+
+OPTIONS:
+        --at <tag or rev>                    Use a specific commit/release instead of the latest. This may be a tag
+                                             name, or a git revision when --branch is set
+    -b, --branch <branch>                    Track a branch instead of a release
+    -d, --directory <folder>                 Base folder for sources.json and the boilerplate default.nix [env:
+                                             NPINS_DIRECTORY=]  [default: npins]
+        --release-prefix <release-prefix>    Optional prefix required for each release name / tag. For example, setting
+                                             this to "release/" will only consider those that start with that string
+        --upper-bound <version>              Bound the version resolution. For example, setting this to "2" will
+                                             restrict updates to 1.X versions. Conflicts with the --branch option
+
+ARGS:
+    <url>    The git remote URL. For example <https://github.com/andir/ate.git>
+```
+
 ### Removing dependencies
 
 ```console

--- a/README.md.in
+++ b/README.md.in
@@ -161,6 +161,13 @@ $ npins help add
 {{npins help add}}
 ```
 
+There are several options for tracking git branches, releases and tags:
+
+```console
+$ npins help add git
+{{npins help add git}}
+```
+
 ### Removing dependencies
 
 ```console

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,6 +81,12 @@ pub struct GenericGitAddOpts {
         conflicts_with_all = &["branch", "at"]
     )]
     pub version_upper_bound: Option<String>,
+
+    /// Optional prefix required for each release name / tag. For
+    /// example, setting this to "release/" will only consider those
+    /// that start with that string.
+    #[structopt(long = "release-prefix")]
+    pub release_prefix: Option<String>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -110,6 +116,7 @@ impl GitHubAddOpts {
                         &self.repository,
                         self.more.pre_releases,
                         self.more.version_upper_bound.clone(),
+                        self.more.release_prefix.clone(),
                     );
                     let version = self.more.at.as_ref().map(|at| GenericVersion {
                         version: at.clone(),
@@ -173,6 +180,7 @@ impl GitLabAddOpts {
                         self.more.pre_releases,
                         self.more.version_upper_bound.clone(),
                         self.private_token.clone(),
+			self.more.release_prefix.clone(),
                     );
                     let version = self.more.at.as_ref()
                         .map(|at| GenericVersion {
@@ -235,6 +243,7 @@ impl GitAddOpts {
                         url,
                         self.more.pre_releases,
                         self.more.version_upper_bound.clone(),
+                        self.more.release_prefix.clone(),
                     );
                     let version = self.more.at.as_ref().map(|at| GenericVersion {
                         version: at.clone(),

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -293,7 +293,7 @@ mod test {
                         hashes: Some(GenericUrlHashes { url: "https://files.pythonhosted.org/packages/c3/9d/ac871992617220442832af12c3808716f4349ab05ff939d695fe8b542f00/streamlit-1.3.1.tar.gz".parse().unwrap(), hash: "adec7935c9cf774b9115b2456cf2f48c4f49b9f67159a97db0fe228357c1afdf".into() } )
                     },
                     "youtube-dl".into() => Pin::GitRelease {
-                        input: git::GitReleasePin::github("ytdl-org", "youtube-dl", false, None),
+                        input: git::GitReleasePin::github("ytdl-org", "youtube-dl", false, None, None),
                         version: Some(GenericVersion { version: "youtube-dl 2021.12.17".into() }),
                         hashes: None,
                     }


### PR DESCRIPTION
This is useful for releases / tags that are of the pattern
release/v1.0 or basepoint/v1.0 such as the tags that are used within
the GCC project.


![image](https://github.com/andir/npins/assets/638836/950c30f3-0470-438f-9632-3610921e509c)
