### PR TITLE
builtins.fetchGit: use same name as nix-prefetch-git

### DIFF
--- a/npins/default.nix
+++ b/npins/default.nix
@@ -27,6 +27,7 @@ let
       revision,
       url ? null,
       hash,
+      branch ? null,
       ...
     }:
     assert repository ? type;
@@ -39,9 +40,23 @@ let
       })
     else
       assert repository.type == "Git";
+      let
+        urlToName =
+          url: rev:
+          let
+            matched = builtins.match "^.*/([^/]*)(\\.git)?$" repository.url;
+
+            short = builtins.substring 0 7 rev;
+
+            appendShort = if (builtins.match "[a-f0-9]*" rev) != null then "-${short}" else "";
+          in
+          "${if matched == null then "source" else builtins.head matched}${appendShort}";
+        name = urlToName repository.url revision;
+      in
       builtins.fetchGit {
         url = repository.url;
         rev = revision;
+        inherit name;
         # hash = hash;
       };
 


### PR DESCRIPTION
When using npins with (generic, i.e. non-github) git repositories, we currently have the issue of having to download these twice: once while doing `npins add git ...`, and then a second time when evaluating the source attribute in Nix.

The source of this is that `nix-prefetch-git`, which we use to get the hash, sets as name for the store path it produces a name derived from the url; this [behaviour is not configurable](https://github.com/NixOS/nixpkgs/blob/c215fb18dc1c4ef927c773078d2365fc559365c5/pkgs/build-support/fetchgit/nix-prefetch-git#L142). In contrast, `builtins.fetchGit` sets the name as `"source"` by default.

The nixpkgs fetcher uses [a nix implementation of the same logic](https://github.com/NixOS/nixpkgs/blob/2116a1123122d639b7c69e47284e4b35198c3fa6/pkgs/build-support/fetchgit/default.nix#L2) to derive the desired name in nix.

This commit adds a function which does the same, derived from the one in Nixpkgs, but tweaked to only use builtin functions, and uses it to set an appropriate name for the git fetcher. With it, a the name exposed by npins to nix code changes to the one that `nix-prefetch-git` also used, thus we avoid this doubled download after adding a new source.

This logic is somewhat delicate. I've added a safe guard so that if it ever fails to extract a name, we fall back to using `"source"` as attribute name.

Note that while this is a similar issue to https://github.com/andir/npins/issues/57, it is (afaict, anyways) not related to `builtins.fetchGit` not using the fetcher cache. That's a separate issue which also causes doubled downloads.