### PR TITLE
 @andir Run smoke test in nix-shell 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Run pre-commit hooks
         run: nix-shell --run "pre-commit run --all"
       - name: Run smoke test
-        run: bash ./.github/workflows/smoke-test.sh
+        run: nix-shell --run "bash ./.github/workflows/smoke-test.sh"
       - name: Run integration tests
         run: nix-build -A meta.tests


### PR DESCRIPTION
This ensures a reproducible nix version is used as the DetSys
installer seems to install whatever the Nix people think is stable...

Apparently that isn't the case so I'll just stick to 2.3 in the smoke
test as well. We could add a newer version of Nix but I don't see the
features or bug fixes that would require supporting anything newer.

Related: https://github.com/NixOS/nix/issues/10395