### PR TITLE
fix warnings

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ let
     inherit system;
     overlays = [
       (self: super: {
-        nixfmt = super.nixfmt.overrideAttrs (old: {
+        nixfmt = super.nixfmt-classic.overrideAttrs (old: {
           src = pins.nixfmt;
         });
       })
@@ -18,9 +18,11 @@ let
   pre-commit = (import pins."pre-commit-hooks.nix").run {
     src = ./.;
     tools.nixfmt = pkgs.nixfmt; # Why don't they just take it from our pkgs?
-    settings.nixfmt.width = 100;
     hooks = {
-      nixfmt.enable = true;
+      nixfmt = {
+        enable = true;
+        settings.width = 100;
+      };
       rustfmt.enable = true;
       update-readme = {
         enable = true;


### PR DESCRIPTION
Fixes two warnings I encountered.

```
trace: warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style
trace: warning: The option `settings.nixfmt' defined in `<unknown-file>' has been renamed to `hooks.nixfmt.settings'.
```