### PR TITLE
shell: add cargo-expand to help see what the Rust macros do

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -42,6 +42,7 @@ pkgs.mkShell {
     with pkgs;
     [
       cargo
+      cargo-expand
       clippy
       rustc
       rust-analyzer


### PR DESCRIPTION
To try it out, run `cargo expand --color=always | less -R` and page through the output.

In particular, I wanted to see what the compiler saw with the `mkPins` macro.