### PR TITLE
Remove wildcard imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/target
-.pre-commit-config.yaml
 .direnv
+.pre-commit-config.yaml
+readme
 /result
+/target
 /test

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2,7 +2,9 @@
 //!
 //! This should be preferred over pinning the equivaleng `nixpkgs` git branch.
 
-use crate::*;
+use crate::{build_client, diff, nix, Updatable};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub struct Pin {

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -1,6 +1,6 @@
 //! Convert+Import Nix flake lock files
 
-use crate::*;
+use crate::{git, Pin};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;

--- a/src/git.rs
+++ b/src/git.rs
@@ -7,7 +7,7 @@
 //! instance. This should be preferred over the generic Git API if possible. See [`Repository`]
 //! for more on this.
 
-use crate::*;
+use crate::{diff, git, nix, GenericVersion, Updatable};
 use anyhow::{Context, Result};
 use lenient_version::Version;
 use serde::{Deserialize, Serialize};

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ where
 /// - **The serialized dictionaries of all are disjoint** (unchecked invariant at the moment)
 #[async_trait::async_trait]
 pub trait Updatable:
-    Serialize + Deserialize<'static> + std::fmt::Debug + Clone + PartialEq + Eq + diff::Diff
+    Serialize + Deserialize<'static> + Clone + PartialEq + Eq + diff::Diff
 {
     /// Version information, produced by the [`update`](Self::update) method.
     ///
@@ -60,24 +60,12 @@ pub trait Updatable:
     /// A user should be able to manually specify it, if they want to pin a specific version.
     /// Each version should map to the same set of hashes over time, and violations of this
     /// should only be caused by upstream errors.
-    type Version: diff::Diff
-        + Serialize
-        + Deserialize<'static>
-        + std::fmt::Debug
-        + Clone
-        + PartialEq
-        + Eq;
+    type Version: diff::Diff + Serialize + Deserialize<'static> + Clone + PartialEq + Eq;
 
     /// The pinned hashes for a given version, produced by the [`fetch`](Self::fetch) method.
     ///
     /// It may contain multiple different hashes, or download URLs that go with them.
-    type Hashes: diff::Diff
-        + Serialize
-        + Deserialize<'static>
-        + std::fmt::Debug
-        + Clone
-        + PartialEq
-        + Eq;
+    type Hashes: diff::Diff + Serialize + Deserialize<'static> + Clone + PartialEq + Eq;
 
     /// Fetch the latest applicable commit data
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,7 @@ where
 /// - **The serialized dictionaries of all are disjoint** (unchecked invariant at the moment)
 #[async_trait::async_trait]
 pub trait Updatable:
-    Serialize
-    + Deserialize<'static>
-    + std::fmt::Debug
-    + Clone
-    + PartialEq
-    + Eq
-    + std::hash::Hash
-    + diff::Diff
+    Serialize + Deserialize<'static> + std::fmt::Debug + Clone + PartialEq + Eq + diff::Diff
 {
     /// Version information, produced by the [`update`](Self::update) method.
     ///

--- a/src/niv.rs
+++ b/src/niv.rs
@@ -1,6 +1,6 @@
 //! Convert+Import Niv files
 
-use crate::*;
+use crate::{git, Pin};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;

--- a/src/pypi.rs
+++ b/src/pypi.rs
@@ -1,6 +1,6 @@
 //! Pin a PyPi package
 
-use crate::*;
+use crate::{diff, get_and_deserialize, GenericUrlHashes, GenericVersion, Updatable};
 use anyhow::{Context, Result};
 use lenient_version::Version;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Things done

- [x] Add `readme` to `.gitignore`
- [x] Wrap comments to fix `cargo fmt` better in `src/main.rs`
- [x] Move from wildcard imports to specific imports to avoid action at a distance
- [x] Remove a few unused trait bounds from `Updatable` (`std::hash::Hash`, `std::fmt::Debug`)
- [x] Update comment referring to nonexistent `NixPinsVersioned` type