### PR TITLE
git: fix fetch on branch

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -73,7 +73,7 @@ let
       url ? null,
       submodules,
       hash,
-      branch ? null,
+      branch ? "HEAD",
       ...
     }:
     assert repository ? type;
@@ -108,6 +108,7 @@ let
         name = urlToName url revision;
       in
       builtins.fetchGit {
+        ref = branch;
         rev = revision;
         inherit name;
         # hash = hash;


### PR DESCRIPTION
npins was not able to use branches different from the default branch in my use case. A test is added, which tries to use test-branch, while the default upstream branch is main. I had to also fix the default branch for other tests while doing this.