### PR TITLE
Fix GitHub release submodules

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -87,7 +87,7 @@ let
         urlToName =
           url: rev:
           let
-            matched = builtins.match "^.*/([^/]*)(\\.git)?$" repository.url;
+            matched = builtins.match "^.*/([^/]*)(\\.git)?$" url;
 
             short = builtins.substring 0 7 rev;
 


### PR DESCRIPTION
This failed due to the `repository.url` being `null`. Since this seems to be on purpose (as there is no tarball that contains all submodules on GitHub) we should have an explicit test case of this (so I added one).