### PR TITLE
Add a newline at the end of sources.json

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -544,9 +544,9 @@ impl Opts {
             std::fs::create_dir(&self.folder)?;
         }
         let path = self.folder.join("sources.json");
-        let fh = std::fs::File::create(&path)
+        let mut fh = std::fs::File::create(&path)
             .with_context(move || format!("Failed to open {} for writing.", path.display()))?;
-        serde_json::to_writer_pretty(fh, &versions::to_value_versioned(pins))?;
+        serde_json::to_writer_pretty(&mut fh, &versions::to_value_versioned(pins))?;
         fh.write_all(b"\n")?;
         Ok(())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -547,6 +547,7 @@ impl Opts {
         let fh = std::fs::File::create(&path)
             .with_context(move || format!("Failed to open {} for writing.", path.display()))?;
         serde_json::to_writer_pretty(fh, &versions::to_value_versioned(pins))?;
+        fh.write_all(b"\n")?;
         Ok(())
     }
 


### PR DESCRIPTION
Sometimes I edit this file by hand, and the editor adds it, sometimes I edit it with `npins`, and it doesn't.
This leads to unnecessary diffs in Git, which makes me sad.

Note that there is no flag for serde to do this, see https://github.com/serde-rs/json/issues/716#issuecomment-709463914.