### PR TITLE
Add concurrency to update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,36 +255,92 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.30"
+name = "futures"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
-name = "futures-task"
-version = "0.3.30"
+name = "futures-executor"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
-
-[[package]]
-name = "futures-util"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -705,6 +761,7 @@ dependencies = [
  "async-trait",
  "env_logger",
  "envtestkit",
+ "futures",
  "lenient_semver_parser",
  "lenient_version",
  "log",
@@ -1050,6 +1107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +183,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -189,6 +195,17 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.8.0",
+ "parking_lot 0.12.3",
+ "rustix",
+]
 
 [[package]]
 name = "displaydoc"
@@ -230,7 +247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea14546e99a5b0e76a883df8ff5531ae2e5f1cd484c88531142ac9bfb11542f"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -238,6 +255,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "fnv"
@@ -695,9 +722,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -759,6 +792,7 @@ version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
+ "crossterm",
  "env_logger",
  "envtestkit",
  "futures",
@@ -806,7 +840,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -818,9 +862,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.8",
+ "smallvec",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -909,7 +966,16 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1002,6 +1068,19 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1.52"
 lenient_semver_parser = { version = "0.4.2", default-features = false }
 lenient_version = { version = "0.4.2" }
 futures = "0.3.31"
+crossterm = { version = "0.28.1", default-features = false }
 
 [dev-dependencies]
 envtestkit = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { version = "^0.12.0", features = [ "rustls-tls" ], default-features =
 async-trait = "0.1.52"
 lenient_semver_parser = { version = "0.4.2", default-features = false }
 lenient_version = { version = "0.4.2" }
+futures = "0.3.31"
 
 [dev-dependencies]
 envtestkit = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -327,9 +327,10 @@ FLAGS:
     -p, --partial    Don't update versions, only re-fetch hashes
 
 OPTIONS:
-        --conc-count <conc-count>    Amount of concurrent updates that will be done at once [default: 5]
-    -d, --directory <folder>         Base folder for sources.json and the boilerplate default.nix [env:
-                                     NPINS_DIRECTORY=]  [default: npins]
+    -d, --directory <folder>
+            Base folder for sources.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]  [default: npins]
+
+        --max-concurrent-downloads <max-concurrent-downloads>    Maximum number of simultaneous downloads [default: 5]
 
 ARGS:
     <names>...    Update only these pins. Duplicate or missing pins will be ignored

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ FLAGS:
     -p, --partial    Don't update versions, only re-fetch hashes
 
 OPTIONS:
-        --conc-count <conc-count>    Amount of concurrent updates that will be done at once
+        --conc-count <conc-count>    Amount of concurrent updates that will be done at once [default: 5]
     -d, --directory <folder>         Base folder for sources.json and the boilerplate default.nix [env:
                                      NPINS_DIRECTORY=]  [default: npins]
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ SUBCOMMANDS:
                     `default.nix` and never touch your sources.json
     remove          Removes one pin entry
     show            Lists the current pin entries
-    update          Updates all or the given pin to the latest version
+    update          Updates all or the given pins to the latest version
     upgrade         Upgrade the sources.json and default.nix to the latest format version. This may occasionally
                     break Nix evaluation!
 ```
@@ -314,7 +314,7 @@ You can decide to update only selected dependencies, or all at once. For some pi
 ```console
 $ npins help update
 npins-update 0.2.4
-Updates all or the given pin to the latest version
+Updates all or the given pins to the latest version
 
 USAGE:
     npins update [FLAGS] [OPTIONS] [names]...
@@ -333,7 +333,7 @@ OPTIONS:
         --max-concurrent-downloads <max-concurrent-downloads>    Maximum number of simultaneous downloads [default: 5]
 
 ARGS:
-    <names>...    Update only these pins. Duplicate or missing pins will be ignored
+    <names>...    Updates only the specified pins
 ```
 
 ### Upgrading the pins file

--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ FLAGS:
     -p, --partial    Don't update versions, only re-fetch hashes
 
 OPTIONS:
-    -d, --directory <folder>    Base folder for sources.json and the boilerplate default.nix [env: NPINS_DIRECTORY=]
-                                [default: npins]
+        --conc-count <conc-count>    Amount of concurrent updates that will be done at once
+    -d, --directory <folder>         Base folder for sources.json and the boilerplate default.nix [env:
+                                     NPINS_DIRECTORY=]  [default: npins]
 
 ARGS:
     <names>...    Update only those pins

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ SUBCOMMANDS:
                     `default.nix` and never touch your sources.json
     remove          Removes one pin entry
     show            Lists the current pin entries
-    update          Updates all or the given pin to the latest version
+    update          Updates all or the given pin to the latest version. Duplicate or missing pins will be ignored
     upgrade         Upgrade the sources.json and default.nix to the latest format version. This may occasionally
                     break Nix evaluation!
 ```
@@ -314,7 +314,7 @@ You can decide to update only selected dependencies, or all at once. For some pi
 ```console
 $ npins help update
 npins-update 0.2.4
-Updates all or the given pin to the latest version
+Updates all or the given pin to the latest version. Duplicate or missing pins will be ignored
 
 USAGE:
     npins update [FLAGS] [OPTIONS] [names]...

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ SUBCOMMANDS:
                     `default.nix` and never touch your sources.json
     remove          Removes one pin entry
     show            Lists the current pin entries
-    update          Updates all or the given pin to the latest version. Duplicate or missing pins will be ignored
+    update          Updates all or the given pin to the latest version
     upgrade         Upgrade the sources.json and default.nix to the latest format version. This may occasionally
                     break Nix evaluation!
 ```
@@ -314,7 +314,7 @@ You can decide to update only selected dependencies, or all at once. For some pi
 ```console
 $ npins help update
 npins-update 0.2.4
-Updates all or the given pin to the latest version. Duplicate or missing pins will be ignored
+Updates all or the given pin to the latest version
 
 USAGE:
     npins update [FLAGS] [OPTIONS] [names]...
@@ -332,7 +332,7 @@ OPTIONS:
                                      NPINS_DIRECTORY=]  [default: npins]
 
 ARGS:
-    <names>...    Update only those pins
+    <names>...    Update only these pins. Duplicate or missing pins will be ignored
 ```
 
 ### Upgrading the pins file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -425,7 +425,8 @@ pub struct RemoveOpts {
 
 #[derive(Debug, StructOpt)]
 pub struct UpdateOpts {
-    /// Update only those pins
+    /// Update only these pins.
+    /// Duplicate or missing pins will be ignored.
     pub names: Vec<String>,
     /// Don't update versions, only re-fetch hashes
     #[structopt(short, long, conflicts_with = "full")]
@@ -482,7 +483,6 @@ pub enum Command {
     Show,
 
     /// Updates all or the given pin to the latest version.
-    /// Duplicate or missing pins will be ignored.
     Update(UpdateOpts),
 
     /// Upgrade the sources.json and default.nix to the latest format version. This may occasionally break Nix evaluation!

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -503,6 +503,7 @@ fn print_diff(name: &str, diff: impl AsRef<[diff::DiffEntry]>) {
     if diff.is_empty() {
         println!("`{name}` No Changes");
     } else {
+        // Lock the stream so that we can print the diff in multiple calls without interleaving prints from other threads
         let mut stdout_lock = stdout().lock();
         writeln!(stdout_lock, "`{name}` Changes:").unwrap();
         for d in diff {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -501,11 +501,11 @@ pub enum Command {
 fn print_diff(name: &str, diff: impl AsRef<[diff::DiffEntry]>) {
     let diff = diff.as_ref();
     if diff.is_empty() {
-        println!("`{name}` No Changes");
+        println!("[{name}] No Changes");
     } else {
         // Lock the stream so that we can print the diff in multiple calls without interleaving prints from other threads
         let mut stdout_lock = stdout().lock();
-        writeln!(stdout_lock, "`{name}` Changes:").unwrap();
+        writeln!(stdout_lock, "[{name}] Changes:").unwrap();
         for d in diff {
             write!(stdout_lock, "{}", d).unwrap();
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,9 +447,9 @@ pub struct UpdateOpts {
     /// Print the diff, but don't write back the changes
     #[structopt(short = "n", long, global = true)]
     pub dry_run: bool,
-    /// Amount of concurrent updates that will be done at once
+    /// Maximum number of simultaneous downloads
     #[structopt(default_value = "5", long)]
-    pub conc_count: usize,
+    pub max_concurrent_downloads: usize,
 }
 
 #[derive(Debug, StructOpt)]
@@ -726,7 +726,7 @@ impl Opts {
             });
 
         stream::iter(update_iter)
-            .buffer_unordered(opts.conc_count)
+            .buffer_unordered(opts.max_concurrent_downloads)
             .try_filter(|(_, diff)| future::ready(diff.is_empty().not()))
             .try_collect::<Vec<_>>()
             .await?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@
 use super::*;
 
 use std::{
-    io::{stdout, Write},
+    io::{stderr, stdout, Write},
     ops::Not,
 };
 
@@ -674,16 +674,16 @@ impl Opts {
 
         for name in pins.pins.keys() {
             if opts.names.is_empty() || opts.names.contains(name) {
-                println!("{} (queued)", name.as_str().grey());
+                eprintln!("{} (queued)", name.as_str().grey());
             } else {
-                println!("{} (ignored)", name.as_str().dark_grey());
+                eprintln!("{} (ignored)", name.as_str().dark_grey());
             }
         }
 
         let pin_writer = |name: StyledContent<&str>, status: &str, index: usize| {
             let seek_distance = (length - index) as u16;
             execute!(
-                stdout(),
+                stderr(),
                 cursor::MoveToPreviousLine(seek_distance),
                 terminal::Clear(terminal::ClearType::CurrentLine),
                 Print(format_args!("{name} ({status})")),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -667,6 +667,7 @@ impl Opts {
             .iter_mut()
             .filter(|(name, _)| opts.names.is_empty() || opts.names.contains(name))
             .map(|(name, pin)| async move {
+                log::info!("Updating '{}' …", name);
                 print_diff(name, Self::update_one(pin, strategy).await?);
                 anyhow::Result::<_, anyhow::Error>::Ok(())
             });


### PR DESCRIPTION
Closes #108

This PR is pretty minimal in what it changes, I'd be happy to also work on other features such as adding a max amount of concurrent updates at once or having a flag to revert back to single threaded mode if its deemed desirable. A progress spinner/bar could also be nice to add later.