### PR TITLE
import-flake: detect default branches correctly

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -851,7 +851,8 @@ impl Opts {
             }
 
             let mut pin: Pin = pin
-                .try_into()
+                .try_to_pin()
+                .await
                 .context("Could not convert pin to npins format")?;
 
             pin.update().await?;


### PR DESCRIPTION
See https://github.com/andir/npins/issues/113

Previously, `npins import-flake` would simply assume that the branch was called `master` if not given, which is not correct; nix flakes will use the remote's default branch in such cases.

This mimics the behaviour in the flake importer — however, perhaps it might be better to move it into the Pin struct itself, allowing branch pins with no explicit branch name given, which then resolve to the remote's default branch instead?