### PR TITLE
Add `meta.mainProgram` to ` npins.nix`

### DIFF
--- a/npins.nix
+++ b/npins.nix
@@ -66,6 +66,7 @@ let
     '';
 
     meta.tests = pkgs.callPackage ./test.nix { npins = self; };
+    meta.mainProgram = cargoToml.package.name;
   };
 in
 self


### PR DESCRIPTION
Sets `meta.mainProgram` to the package name so that `lib.meta.getExe` doesn't throw warnings about it.