### PR TITLE
Add support for flakes "Lockable HTTP Tarball Protocol"

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Commands:
   gitlab   Track a GitLab repository
   git      Track a git repository
   pypi     Track a package on PyPi
+  tarball  Track a tarball
   help     Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/default.nix
+++ b/src/default.nix
@@ -59,6 +59,8 @@ let
           mkPyPiSource spec
         else if spec.type == "Channel" then
           mkChannelSource spec
+        else if spec.type == "Tarball" then
+          mkTarballSource spec
         else
           builtins.throw "Unknown source type ${spec.type}";
     in
@@ -125,8 +127,20 @@ let
       inherit url;
       sha256 = hash;
     };
+
+  mkTarballSource =
+    {
+      url,
+      locked_url ? url,
+      hash,
+      ...
+    }:
+    builtins.fetchTarball {
+      url = locked_url;
+      sha256 = hash;
+    };
 in
-if version == 4 then
+if version == 5 then
   builtins.mapAttrs mkSource data.pins
 else
   throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -24,6 +24,7 @@ enum FlakeType {
     Github,
     Git,
     Path,
+    Tarball,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,6 +53,8 @@ pub struct FlakeOriginal {
     ref_: Option<String>,
     #[serde(rename = "type")]
     type_: String,
+    /// the url of a lockable tarball
+    url: Option<Url>,
 }
 
 impl FlakePin {
@@ -115,6 +118,13 @@ impl FlakePin {
                     false,
                 )
                 .into()
+            },
+            Tarball => {
+                let url = self
+                    .original
+                    .url
+                    .context("missing url on a tarball flake input")?;
+                tarball::TarballPin { url }.into()
             },
             Path => anyhow::bail!("Path inputs are currently not supported by npins."),
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ pub mod git;
 pub mod niv;
 pub mod nix;
 pub mod pypi;
+pub mod tarball;
 pub mod versions;
 
 /// Helper method to build you a client.
@@ -250,6 +251,7 @@ mkPin! {
     (GitRelease, git_release, "git release tag", git::GitReleasePin),
     (PyPi, pypi, "pypi package", pypi::Pin),
     (Channel, channel, "Nix channel", channel::Pin),
+    (Tarball, tarball, "tarball", tarball::TarballPin),
 }
 
 /// The main struct the CLI operates on
@@ -282,6 +284,17 @@ pub struct GenericVersion {
 impl diff::Diff for GenericVersion {
     fn properties(&self) -> Vec<(String, String)> {
         vec![("version".into(), self.version.clone())]
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct GenericHash {
+    pub hash: String,
+}
+
+impl diff::Diff for GenericHash {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![("hash".into(), self.hash.clone())]
     }
 }
 

--- a/src/tarball.rs
+++ b/src/tarball.rs
@@ -1,0 +1,97 @@
+//! Pin a tarball URL source
+//!
+//! Optionally (if the host supports it) can use the "Lockable HTTP Tarball Protocol" from flakes.
+//! Reference: <https://github.com/nixos/nix/blob/56763ff918eb308db23080e560ed2ea3e00c80a7/doc/manual/src/protocols/tarball-fetcher.md>
+
+use anyhow::{Context, Result};
+use reqwest::header::HeaderName;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::*;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct TarballPin {
+    /// URL provided as user input
+    pub url: Url,
+}
+
+impl diff::Diff for TarballPin {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![("url".into(), self.url.to_string())]
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct LockedTarball {
+    /// If the given URL supports the Lockable Tarball Protocol we store the
+    /// flakeref here
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked_url: Option<Url>,
+}
+
+impl diff::Diff for LockedTarball {
+    fn properties(&self) -> Vec<(String, String)> {
+        self.locked_url
+            .iter()
+            .map(|locked_url| ("locked_url".into(), locked_url.to_string()))
+            .collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl Updatable for TarballPin {
+    type Version = LockedTarball;
+    type Hashes = GenericHash;
+
+    async fn update(&self, old: Option<&LockedTarball>) -> Result<LockedTarball> {
+        const LINK: HeaderName = HeaderName::from_static("link");
+
+        // Attempt to use the Lockable HTTP Tarball Protocol, if that fails (the
+        // expected Link header is missing) we fail back to using whatever was
+        // the input.
+        let headers = build_client()?
+            .head(self.url.clone())
+            .send()
+            .await?
+            .headers()
+            .clone();
+        let flakerefs = headers
+            .get_all(LINK)
+            .into_iter()
+            .filter_map(|header| header.to_str().ok())
+            .filter_map(|link| {
+                // Naive parsing of the `Link: <flakeref>; rel="immutable"` header
+                link.strip_suffix(r#">; rel="immutable""#)?
+                    .strip_prefix("<")
+            })
+            .collect::<Vec<_>>();
+        let locked_url = if let [flakeref] = flakerefs[..] {
+            Some(
+                flakeref
+                    .parse::<Url>()
+                    .context("immutable link contained an invalid URL")?,
+            )
+        } else {
+            if matches!(old, Some(old) if old.locked_url.is_some()) {
+                log::warn!(
+                    "url `{url}` of a locked tarball pin did not respond with the expected `Link` header. \
+                     if you changed the `url` manually to one that doesn't support this protocol make sure to also remove the `locked_url` field. \
+                     https://docs.lix.systems/manual/lix/nightly/protocols/tarball-fetcher.html",
+                    url = &self.url,
+                );
+                return Ok(old.unwrap().clone());
+            } else {
+                // This is a no-op since we started with `old.locked_url.is_none()`
+                None
+            }
+        };
+        Ok(LockedTarball { locked_url })
+    }
+
+    async fn fetch(&self, version: &LockedTarball) -> Result<GenericHash> {
+        let url = version.locked_url.as_ref().unwrap_or(&self.url);
+        let hash = nix::nix_prefetch_tarball(&url).await?;
+        Ok(GenericHash { hash })
+    }
+}

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Map, Value};
 
 /// The current format version
-pub const LATEST: u64 = 4;
+pub const LATEST: u64 = 5;
 
 /// Custom manual deserialize wrapper that checks the version
 pub fn from_value_versioned(value: Value) -> Result<NixPins> {
@@ -74,10 +74,10 @@ pub fn upgrade(mut pins_raw: Map<String, Value>) -> Result<Value> {
             }
         },
         // All these versions are already handled by serde default fields
-        1 | 2 | 3 => {
+        1 | 2 | 3 | 4 => {
             log::info!("There is nothing to do");
         },
-        4 => {
+        5 => {
             log::info!("sources.json is already up to date");
         },
         unknown => {


### PR DESCRIPTION
Hi, i've run into missing support for the "tarball" type of flake input when importing a flake. I've noticed it's been mentioned before in #47 so i gave it a try because it doesn't look very complicated.

This is just a quick experiment, if you want this this feature included in npins i'm happy to write tests and anything else that is missing^^

For now i've tested it only manually on my nixos config using
```sh
mkdir test && cd test
cargo run -- init --bare
wget https://git.p2502.net/max/nixconf/raw/branch/main/flake.lock
cargo run -- import-flake
cargo run -- show
```