### PR TITLE
cli: Fix reported file name

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -649,7 +649,7 @@ impl Opts {
             if self.folder.join("sources.json").exists() {
                 log::info!(
                     "The file '{}' already exists; nothing to do.",
-                    self.folder.join("pins.json").display()
+                    self.folder.join("sources.json").display()
                 );
                 return Ok(());
             }


### PR DESCRIPTION
There may be more to do, now that *lockfile mode* is a thing. The file name may be different, in other code paths, too.