### PR TITLE
Multiple improments for test.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
 .pre-commit-config.yaml
 .direnv
-/result
+/result*
 /test

--- a/test.nix
+++ b/test.nix
@@ -50,6 +50,8 @@ let
     }:
     pkgs.runCommand "git-repo" { nativeBuildInputs = [ pkgs.gitMinimal ]; } ''
       export HOME=$TMP
+      export GIT_AUTHOR_DATE="1970-01-01 00:00:00 +0000"
+      export GIT_COMMITTER_DATE="1970-01-01 00:00:00 +0000"
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"
       git config --global init.defaultBranch main

--- a/test.nix
+++ b/test.nix
@@ -338,6 +338,24 @@ let
 
         touch $out
       '';
+
+  mkPrefetchGitTest =
+    name: npinsArgs:
+    mkGitTest {
+      name = "nix-prefetch-git-${name}";
+      repositories."foo" = gitRepo;
+      commands = ''
+        npins init --bare
+        npins add git http://localhost:8000/foo ${npinsArgs}
+        before=$(ls /build)
+
+        nix-instantiate --eval npins -A foo.outPath.outPath
+        after=$(ls /build)
+        cat npins/sources.json
+
+        [[ "$before" = "$after" ]]
+      '';
+    };
 in
 {
   initNoDefaultNix = mkGitTest {
@@ -690,31 +708,9 @@ in
     '';
   };
 
-  nixPrefetch =
-    let
-      mkPrefetchGitTest =
-        name: npinsArgs:
-        mkGitTest {
-          name = "nix-prefetch-git-${name}";
-          inherit gitRepo;
-          commands = ''
-            npins init --bare
-            npins add git http://localhost:8000/foo ${npinsArgs}
-            before=$(ls /build)
-
-            nix-instantiate --eval npins -A foo.outPath.outPath
-            after=$(ls /build)
-            cat npins/sources.json
-
-            [[ "$before" = "$after" ]]
-          '';
-        };
-    in
-    {
-      branch = mkPrefetchGitTest "branch" "--branch test-branch";
-      tag = mkPrefetchGitTest "tag" "--at v0.2";
-      hash = mkPrefetchGitTest "hash" "--branch test-branch --at 9ba40d123c3e6adb35c99ad04fd9de6bcdc1c9d5";
-    };
+  nixPrefetchBranch = mkPrefetchGitTest "branch" "--branch test-branch";
+  nixPrefetchTag = mkPrefetchGitTest "tag" "--at v0.2";
+  nixPrefetchHash = mkPrefetchGitTest "hash" "--branch test-branch --at 9ba40d123c3e6adb35c99ad04fd9de6bcdc1c9d5";
 
   importGitFromFlake =
     let

--- a/test.nix
+++ b/test.nix
@@ -739,7 +739,7 @@ in
 
   nixPrefetchBranch = mkPrefetchGitTest "branch" "--branch test-branch";
   nixPrefetchTag = mkPrefetchGitTest "tag" "--at v0.2";
-  nixPrefetchHash = mkPrefetchGitTest "hash" "--branch test-branch --at 9ba40d123c3e6adb35c99ad04fd9de6bcdc1c9d5";
+  nixPrefetchHash = mkPrefetchGitTest "hash" "--branch test-branch --at 81289a3c12d4f528d27794b9e47f4ff5cf534a88";
 
   importGitFromFlake =
     let


### PR DESCRIPTION
- Run `importGitFromFlake` test when `nix-build -A meta.tests`
- Run `nixPrefetch*` test when `nix-build -A meta.tests`
- Use git-http-backend CGI to serve git repo for shallow clone capabilities
- Make the test git repo reproducible

Note: The `importGitFromFlake` and `nixPrefetch*` tests was never run in the github workflow, this PR fix them.