### PR TITLE
fix the source name when calling `nix-prefetch-url`

### DIFF
--- a/src/nix.rs
+++ b/src/nix.rs
@@ -10,11 +10,13 @@ pub struct PrefetchInfo {
 pub async fn nix_prefetch_tarball(url: impl AsRef<str>) -> Result<String> {
     let url = url.as_ref();
     log::debug!(
-        "Executing `nix-prefetch-url --unpack --type sha256 {}`",
+        "Executing `nix-prefetch-url --unpack --name source --type sha256 {}`",
         url
     );
     let output = tokio::process::Command::new("nix-prefetch-url")
         .arg("--unpack") // force calculation of the unpacked NAR hash
+        .arg("--name")
+        .arg("source") // use the same symbolic store path name as `builtins.fetchTarball` to avoid downloading the source twice
         .arg("--type")
         .arg("sha256")
         .arg(url)


### PR DESCRIPTION
since by default `nix-prefetch-url` derives the symbolic store path name from the URL, but `builtins.fetchTarball` does not, setting `--name source` avoids downloading a source twice:
1. when running `npins add`
2. when evaluating `default.nix`

Closes https://github.com/andir/npins/issues/57 based on @roberth's suggestion in https://github.com/NixOS/nix/issues/10881#issuecomment-2573507168

This change is transparent for existing users of `npins`: The symbolic store path name is only different from previous versions *on first download* when running `npins add` or `npins update`, which would produce a new store path anyway.