### PR TITLE
add pinning container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,14 +200,15 @@ Adds a new pin entry
 Usage: npins add [OPTIONS] <COMMAND>
 
 Commands:
-  channel  Track a Nix channel
-  github   Track a GitHub repository
-  forgejo  Track a Forgejo repository
-  gitlab   Track a GitLab repository
-  git      Track a git repository
-  pypi     Track a package on PyPi
-  tarball  Track a tarball
-  help     Print this message or the help of the given subcommand(s)
+  channel    Track a Nix channel
+  github     Track a GitHub repository
+  forgejo    Track a Forgejo repository
+  gitlab     Track a GitLab repository
+  git        Track a git repository
+  pypi       Track a package on PyPi
+  container  Track an OCI container
+  tarball    Track a tarball
+  help       Print this message or the help of the given subcommand(s)
 
 Options:
       --name <NAME>  Add the pin with a custom name. If a pin with that name already exists, it will be overwritten

--- a/npins.nix
+++ b/npins.nix
@@ -7,10 +7,10 @@
   runCommand,
   stdenv,
   darwin,
-
   # runtime dependencies
   lix, # for nix-prefetch-url
   nix-prefetch-git,
+  nix-prefetch-docker,
   git, # for git ls-remote
 }:
 let
@@ -44,6 +44,7 @@ let
   runtimePath = lib.makeBinPath [
     lix
     nix-prefetch-git
+    nix-prefetch-docker
     git
   ];
   self = rustPlatform.buildRustPackage {

--- a/shell.nix
+++ b/shell.nix
@@ -40,6 +40,7 @@ pkgs.mkShell {
       nixfmt-rfc-style
       lix
       nix-prefetch-git
+      nix-prefetch-docker
       git
       npins
     ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -294,6 +294,25 @@ impl PyPiAddOpts {
 }
 
 #[derive(Debug, Parser)]
+pub struct ContainerAddOpts {
+    pub image_name: String,
+    pub image_tag: String,
+}
+
+impl ContainerAddOpts {
+    pub fn add(&self) -> Result<(Option<String>, Pin)> {
+        Ok((
+            Some(self.image_name.clone()),
+            container::Pin {
+                image_name: self.image_name.clone(),
+                image_tag: self.image_tag.clone(),
+            }
+            .into(),
+        ))
+    }
+}
+
+#[derive(Debug, Parser)]
 pub struct TarballAddOpts {
     /// Tarball URL
     pub url: Url,
@@ -326,6 +345,9 @@ pub enum AddCommands {
     /// Track a package on PyPi
     #[command(name = "pypi")]
     PyPi(PyPiAddOpts),
+    /// Track an OCI container
+    #[command(name = "container")]
+    Container(ContainerAddOpts),
     /// Track a tarball
     ///
     /// This can be either a static URL that never changes its contents or a
@@ -360,6 +382,7 @@ impl AddOpts {
             AddCommands::GitLab(gl) => gl.add()?,
             AddCommands::PyPi(p) => p.add()?,
             AddCommands::Tarball(p) => p.add()?,
+            AddCommands::Container(p) => p.add()?,
         };
 
         let name = match (&self.name, name) {

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,0 +1,69 @@
+//! Pin an OCI container
+
+use crate::nix::nix_prefetch_docker;
+use crate::*;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct Pin {
+    pub image_name: String,
+    pub image_tag: String,
+}
+
+impl diff::Diff for Pin {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![
+            ("image_name".into(), self.image_name.clone()),
+            ("image_tag".into(), self.image_tag.clone()),
+        ]
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ContainerVersion {
+    pub image_digest: String,
+}
+
+impl diff::Diff for ContainerVersion {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![("image_digest".into(), self.image_digest.to_string())]
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ContainerHash {
+    pub hash: String,
+}
+
+impl diff::Diff for ContainerHash {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![("hash".into(), self.hash.to_string())]
+    }
+}
+
+#[async_trait::async_trait]
+impl Updatable for Pin {
+    type Version = ContainerVersion;
+    type Hashes = ContainerHash;
+
+    async fn update(&self, _old: Option<&ContainerVersion>) -> Result<ContainerVersion> {
+        Ok(ContainerVersion {
+            image_digest: nix_prefetch_docker(&self.image_name, &self.image_tag, None)
+                .await?
+                .image_digest,
+        })
+    }
+
+    async fn fetch(&self, version: &ContainerVersion) -> Result<ContainerHash> {
+        Ok(ContainerHash {
+            hash: nix_prefetch_docker(
+                &self.image_name,
+                &self.image_tag,
+                Some(&version.image_digest),
+            )
+            .await?
+            .hash,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 pub mod channel;
+pub mod container;
 pub mod diff;
 pub mod flake;
 pub mod git;
@@ -287,6 +288,7 @@ mkPin! {
     (PyPi, pypi, "pypi package", pypi::Pin),
     (Channel, channel, "Nix channel", channel::Pin),
     (Tarball, tarball, "tarball", tarball::TarballPin),
+    (Container, container, "OCI Container", container::Pin),
 }
 
 /// The main struct the CLI operates on

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -125,3 +125,69 @@ pub async fn nix_prefetch_git(
     };
     check_git_url(result.await, url).await
 }
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+pub struct NixPrefetchDockerResponse {
+    pub hash: String,
+    #[serde(rename = "imageName")]
+    pub image_name: String,
+    #[serde(rename = "imageDigest")]
+    pub image_digest: String,
+    #[serde(rename = "finalImageName")]
+    pub final_image_name: String,
+    #[serde(rename = "finalImageTag")]
+    pub final_image_tag: String,
+}
+
+pub async fn nix_prefetch_docker(
+    image_name: impl AsRef<str>,
+    image_tag: impl AsRef<str>,
+    image_digest: Option<&str>,
+) -> Result<NixPrefetchDockerResponse> {
+    let image_name = image_name.as_ref();
+    let image_tag = image_tag.as_ref();
+
+    log::debug!(
+        "Executing: `nix-prefetch-docker {} {}{}`",
+        image_name,
+        image_tag,
+        match image_digest {
+            Some(x) => format!(" --image-digest {}", x),
+            None => "".into(),
+        }
+    );
+    println!("{} {}", image_name, image_tag);
+    let mut output = tokio::process::Command::new("nix-prefetch-docker");
+    let output = output
+        .arg(image_name)
+        .arg(image_tag)
+        .arg("--json")
+        .arg("--quiet");
+    let output = match image_digest {
+        Some(x) => output.arg("--image-digest").arg(x),
+        None => output,
+    };
+    let output = output.output().await.with_context(|| {
+        format!(
+            "Failed to spawn nix-prefetch-docker for {}:{}",
+            image_name, image_tag
+        )
+    })?;
+
+    // FIXME: handle errors and pipe stderr through
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(format!(
+            "failed to prefetch docker: {}\n{}",
+            image_name,
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    log::debug!(
+        "nix-prefetch-git output: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    Ok(serde_json::from_slice(&output.stdout)
+        .context("Failed to deserialize nix-pfetch-git JSON response.")?)
+}


### PR DESCRIPTION
fixes #126

adds support for pinning OCI containers with the help of the `nix-prefetch-docker` command