### PR TITLE
Add timestamps to updates for GitHub repositories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ url = { version = "^2.5", features = [ "serde" ] }
 anyhow = "^1.0"
 tokio = { version = "^1.0", features = ["macros", "rt-multi-thread", "process"] }
 log = "^0.4"
-reqwest = { version = "^0.12.0", features = [ "rustls-tls-native-roots" ], default-features = false }
+reqwest = { version = "^0.12.0", features = [ "rustls-tls-native-roots", "json" ], default-features = false }
 async-trait = "0.1"
 lenient_semver_parser = { version = "0.4.2", default-features = false }
 lenient_version = { version = "0.4.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ macro_rules! mkPin {
                         let properties = input.properties().into_iter()
                             .chain(version.iter().flat_map(Diff::properties))
                             .chain(hashes.iter().flat_map(Diff::properties))
-			    .chain(frozen.properties());
+                            .chain(frozen.properties());
                         for (key, value) in properties {
                             writeln!(fmt, "    {}: {}", key, value)?;
                         }

--- a/test.nix
+++ b/test.nix
@@ -346,13 +346,19 @@ let
                 ln -s ${testTarball} $tarballPath/${path}
                 ln -s ${testTarball} $archivePath/${path}.tar.gz
               '') apiTarballs}
+              commitsPath="api/repos/${repoPath}/commits"
+              commitsApiResponse=$(mktemp)
+              echo '{"commit":{"author":{"date":"1970-01-01T00:00:00Z"}}}' > "$commitsApiResponse"
+              mkdir -p $commitsPath
 
               chmod -R +rw $archivePath
               chmod -R +rw $tarballPath
+              chmod -R +rw $commitsPath
               pwd
               ls -la $tarballPath
               # For each of the commits in the repo create the tarballs
               git config --global --add safe.directory ${gitRepo}
+              git -C ${gitRepo} log --oneline --format="format:%H" | xargs -I XX -n1 cp "$commitsApiResponse" "$commitsPath"/XX
               git -C ${gitRepo} log --oneline --format="format:%H" | xargs -I XX -n1 git -C ${gitRepo} archive -o $PWD/$tarballPath/XX XX
               git -C ${gitRepo} log --oneline --format="format:%H" | xargs -I XX -n1 git -C ${gitRepo} archive -o $PWD/$archivePath/XX.tar.gz XX
             ''


### PR DESCRIPTION
A simple feature addition: fetch the timestamp of the commit during `npins update`. I wanted this because `nix flake update` had it.

If something's not written perfectly, please let me know and I can try to do it better.

> Note: I haven't used my fork for extensive testing yet. I will fix any bugs I find in my fork.

## Features

- Currently supports GitHub.
- After update, displays that the commit timestamp has changed.
- Timestamp is handled as plain text (to avoid adding an extra dependency)
- Displays N/A if timestamp is not available.

## Future work

Add API calls for other providers in `timestamp_url`.