### PR TITLE
default.nix: ensure fetchzip can extract tarballs; fixes #161

### DIFF
--- a/src/default.nix
+++ b/src/default.nix
@@ -71,7 +71,15 @@ let
           }
         else
           {
-            fetchTarball = pkgs.fetchzip;
+            fetchTarball =
+              {
+                url,
+                sha256,
+              }:
+              pkgs.fetchzip {
+                inherit url sha256;
+                extension = "tar";
+              };
             inherit (pkgs) fetchurl;
             fetchGit =
               {


### PR DESCRIPTION
makes a wrapper around fetchzip to add extension = "tar";
simplest thing I can think of, open to improve this further if possible