### PR TITLE
Support showing just a single pin entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `npins show` now accepts a list of pin entries to show instead of always showing the complete list (https://github.com/andir/npins/pull/190)
+
 ## 0.4.0
 
 - Changed the hashes to use the SRI format (https://github.com/andir/npins/pull/139)

--- a/README.md
+++ b/README.md
@@ -298,7 +298,10 @@ This will print the currently pinned dependencies in a human readable format. Th
 $ npins help show
 Lists the current pin entries
 
-Usage: npins show [OPTIONS]
+Usage: npins show [OPTIONS] [NAMES]...
+
+Arguments:
+  [NAMES]...  Name of the pin to show
 
 Options:
   -v, --verbose  Print debug messages


### PR DESCRIPTION
Previously `npins show` would always display the whole list of pins. This got very annoying in larger projects with hundreds of external dependencies.