### PR TITLE
cli: fail on updates with no valid pins

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -758,6 +758,10 @@ impl Opts {
             selected_pins.len()
         };
 
+        if length == 0 {
+            return Err(anyhow::anyhow!("no valid pin selected for update"));
+        }
+
         let strategy = match (opts.partial, opts.full) {
             (false, false) => UpdateStrategy::Normal,
             (false, true) => UpdateStrategy::Full,


### PR DESCRIPTION
Minimal patch to address https://github.com/andir/npins/issues/175

If no pin is selected, npins should fail an update. Can happen when:
- there are no pins
- all specified pins do not exist
- all pins were frozen

Points for discussion:
- should we fail if all specified pins were frozen (but *do* exist)?
- should we fail only if *all* specified pins don't exist (this patch) or if only *some* do not exist?

Also a question for the maintainers: is simply returning an anyhow::Error the correct approach here? It is consistent with other errors in npins, but I was a little surprised (and initially implemented the message by using `log::error!` instead, so it prints nicely)