### PR TITLE
Remove deprecated darwin support packages

### DIFF
--- a/npins.nix
+++ b/npins.nix
@@ -58,7 +58,6 @@ let
 
     inherit src;
 
-    buildInputs = lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ]);
     nativeBuildInputs = [ makeWrapper ];
 
     cargoBuildFlags = [

--- a/shell.nix
+++ b/shell.nix
@@ -46,7 +46,6 @@ pkgs.mkShell {
     ]
     ++ (lib.optionals stdenv.isDarwin [
       pkgs.libiconv
-      pkgs.darwin.apple_sdk.frameworks.Security
     ]);
 
   inherit (pre-commit) shellHook;


### PR DESCRIPTION
(Un)fortunately I'm still using a MacBook for $dayjob and when updating the local Nix userland I ran into compilation errors.

It seems like we don't need those sdk things in the packaging and in the shell code.