### PR TITLE
Fix initial path double slash in forgejo urls

### DIFF
--- a/libnpins/src/git.rs
+++ b/libnpins/src/git.rs
@@ -29,7 +29,8 @@ fn get_github_api_url() -> String {
 fn strip_url(mut url: Url) -> Url {
     url.set_query(None);
     url.set_fragment(None);
-    url.set_path("");
+    // Special URLs like http will always have a slash and not be empty
+    url.set_path("/");
     url
 }
 
@@ -298,7 +299,7 @@ impl Repository {
                 repo,
             } => {
                 let mut server = server.clone();
-                server.set_path(&format!("{owner}/{repo}.git"));
+                server.set_path(&format!("/{owner}/{repo}.git"));
                 server
             },
             Repository::GitLab {
@@ -337,7 +338,11 @@ impl Repository {
                 server,
                 owner,
                 repo,
-            } => Some(format!("{server}{owner}/{repo}/archive/{revision}.tar.gz",).parse()?),
+            } => {
+                let mut server = server.clone();
+                server.set_path(&format!("/{owner}/{repo}/archive/{revision}.tar.gz"));
+                Some(server)
+            },
             Repository::GitLab {
                 repo_path,
                 server,


### PR DESCRIPTION
Pointed out in #204