### PR TITLE
Add file pin type for plain URL downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Commands:
   pypi       Track a package on PyPi
   container  Track an OCI container
   tarball    Track a tarball
-  file       Track a file download
+  fetchurl   Track a plain file download
   help       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Commands:
   pypi       Track a package on PyPi
   container  Track an OCI container
   tarball    Track a tarball
+  file       Track a file download
   help       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Commands:
   pypi       Track a package on PyPi
   container  Track an OCI container
   tarball    Track a tarball
-  fetchurl   Track a plain file download
+  fetchurl   Pin a file through a URL
   help       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -245,7 +245,7 @@ mkFunctor (
         throw "Unsupported input type ${builtins.typeOf input}, must be a path or an attrset";
     version = data.version;
   in
-  if version == 7 then
+  if version == 8 then
     builtins.mapAttrs (name: spec: mkFunctor (mkSource name spec)) data.pins
   else
     throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -108,6 +108,8 @@ let
           mkChannelSource fetchers spec
         else if spec.type == "Tarball" then
           mkTarballSource fetchers spec
+        else if spec.type == "File" then
+          mkFileSource fetchers spec
         else if spec.type == "Container" then
           mkContainerSource pkgs spec
         else
@@ -203,6 +205,18 @@ let
     }:
     fetchTarball {
       url = locked_url;
+      sha256 = hash;
+    };
+
+  mkFileSource =
+    { fetchurl, ... }:
+    {
+      url,
+      hash,
+      ...
+    }:
+    fetchurl {
+      inherit url;
       sha256 = hash;
     };
 

--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -108,8 +108,8 @@ let
           mkChannelSource fetchers spec
         else if spec.type == "Tarball" then
           mkTarballSource fetchers spec
-        else if spec.type == "File" then
-          mkFileSource fetchers spec
+        else if spec.type == "Fetchurl" then
+          mkFetchurlSource fetchers spec
         else if spec.type == "Container" then
           mkContainerSource pkgs spec
         else
@@ -208,7 +208,7 @@ let
       sha256 = hash;
     };
 
-  mkFileSource =
+  mkFetchurlSource =
     { fetchurl, ... }:
     {
       url,

--- a/libnpins/src/fetchurl.rs
+++ b/libnpins/src/fetchurl.rs
@@ -99,23 +99,4 @@ mod test {
         assert_eq!(value["url"], "https://example.com/file.bin");
         assert!(value["hash"].as_str().unwrap().starts_with("sha256-"));
     }
-
-    #[tokio::test]
-    async fn test_fetchurl_update_and_fetch() {
-        // A small file served from the Nix cache. It is not strictly
-        // immutable (new fields may be added over time), but in practice it
-        // is stable enough to make for a reasonable fetch target in tests.
-        let pin = FetchurlPin {
-            url: "https://cache.nixos.org/nix-cache-info".parse().unwrap(),
-        };
-
-        let version = pin.update(None).await.unwrap();
-        assert_eq!(version, FetchurlVersion {});
-
-        let hashes = pin.fetch(&version).await.unwrap();
-        assert_eq!(
-            hashes.hash,
-            NixHash::from_sri("sha256-LJ3jc651pScWN2NQNERaXNOmrjWsbDBtQMDgZ2R4WJc=").unwrap(),
-        );
-    }
 }

--- a/libnpins/src/fetchurl.rs
+++ b/libnpins/src/fetchurl.rs
@@ -11,36 +11,36 @@ use url::Url;
 use crate::{GenericHash, Updatable, diff, nix};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
-pub struct FilePin {
+pub struct FetchurlPin {
     pub url: Url,
 }
 
-impl diff::Diff for FilePin {
+impl diff::Diff for FetchurlPin {
     fn properties(&self) -> Vec<(String, String)> {
         vec![("url".into(), self.url.to_string())]
     }
 }
 
-/// File pins have no meaningful version; the URL is assumed to be static.
+/// Fetchurl pins have no meaningful version; the URL is assumed to be static.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct FileVersion {}
+pub struct FetchurlVersion {}
 
-impl diff::Diff for FileVersion {
+impl diff::Diff for FetchurlVersion {
     fn properties(&self) -> Vec<(String, String)> {
         vec![]
     }
 }
 
 #[async_trait::async_trait]
-impl Updatable for FilePin {
-    type Version = FileVersion;
+impl Updatable for FetchurlPin {
+    type Version = FetchurlVersion;
     type Hashes = GenericHash;
 
-    async fn update(&self, _old: Option<&FileVersion>) -> Result<FileVersion> {
-        Ok(FileVersion {})
+    async fn update(&self, _old: Option<&FetchurlVersion>) -> Result<FetchurlVersion> {
+        Ok(FetchurlVersion {})
     }
 
-    async fn fetch(&self, _version: &FileVersion) -> Result<Self::Hashes> {
+    async fn fetch(&self, _version: &FetchurlVersion) -> Result<Self::Hashes> {
         let hash = nix::nix_prefetch_url(&self.url).await?;
         Ok(Self::Hashes { hash })
     }
@@ -53,15 +53,15 @@ mod test {
     use nix_compat::nixhash::NixHash;
 
     #[test]
-    fn test_file_pin_roundtrip() {
+    fn test_fetchurl_pin_roundtrip() {
         let pins = NixPins {
             pins: [(
                 "test-file".into(),
-                Pin::File {
-                    input: FilePin {
+                Pin::Fetchurl {
+                    input: FetchurlPin {
                         url: "https://example.com/some-file.iso".parse().unwrap(),
                     },
-                    version: Some(FileVersion {}),
+                    version: Some(FetchurlVersion {}),
                     hashes: Some(GenericHash {
                         hash: NixHash::from_sri(
                             "sha256-K9yBph93OLTNw02Q6e9CYFGrUhvEXnh45vrZqIRWfvQ=",
@@ -81,12 +81,12 @@ mod test {
     }
 
     #[test]
-    fn test_file_pin_serialization_shape() {
-        let pin = Pin::File {
-            input: FilePin {
+    fn test_fetchurl_pin_serialization_shape() {
+        let pin = Pin::Fetchurl {
+            input: FetchurlPin {
                 url: "https://example.com/file.bin".parse().unwrap(),
             },
-            version: Some(FileVersion {}),
+            version: Some(FetchurlVersion {}),
             hashes: Some(GenericHash {
                 hash: NixHash::from_sri("sha256-K9yBph93OLTNw02Q6e9CYFGrUhvEXnh45vrZqIRWfvQ=")
                     .unwrap(),
@@ -95,22 +95,22 @@ mod test {
         };
 
         let value = serde_json::to_value(&pin).unwrap();
-        assert_eq!(value["type"], "File");
+        assert_eq!(value["type"], "Fetchurl");
         assert_eq!(value["url"], "https://example.com/file.bin");
         assert!(value["hash"].as_str().unwrap().starts_with("sha256-"));
     }
 
     #[tokio::test]
-    async fn test_file_update_and_fetch() {
+    async fn test_fetchurl_update_and_fetch() {
         // A small, immutable file served from the Nix cache. Its contents
         // (store dir, priority, ...) are part of the cache's public contract
         // and are not expected to change.
-        let pin = FilePin {
+        let pin = FetchurlPin {
             url: "https://cache.nixos.org/nix-cache-info".parse().unwrap(),
         };
 
         let version = pin.update(None).await.unwrap();
-        assert_eq!(version, FileVersion {});
+        assert_eq!(version, FetchurlVersion {});
 
         let hashes = pin.fetch(&version).await.unwrap();
         assert_eq!(

--- a/libnpins/src/fetchurl.rs
+++ b/libnpins/src/fetchurl.rs
@@ -102,9 +102,9 @@ mod test {
 
     #[tokio::test]
     async fn test_fetchurl_update_and_fetch() {
-        // A small, immutable file served from the Nix cache. Its contents
-        // (store dir, priority, ...) are part of the cache's public contract
-        // and are not expected to change.
+        // A small file served from the Nix cache. It is not strictly
+        // immutable (new fields may be added over time), but in practice it
+        // is stable enough to make for a reasonable fetch target in tests.
         let pin = FetchurlPin {
             url: "https://cache.nixos.org/nix-cache-info".parse().unwrap(),
         };

--- a/libnpins/src/file.rs
+++ b/libnpins/src/file.rs
@@ -102,18 +102,20 @@ mod test {
 
     #[tokio::test]
     async fn test_file_update_and_fetch() {
-        // Use a small, stable file from the Nix cache
+        // A small, immutable file served from the Nix cache. Its contents
+        // (store dir, priority, ...) are part of the cache's public contract
+        // and are not expected to change.
         let pin = FilePin {
-            url: "https://raw.githubusercontent.com/NixOS/nixpkgs/master/README.md"
-                .parse()
-                .unwrap(),
+            url: "https://cache.nixos.org/nix-cache-info".parse().unwrap(),
         };
 
         let version = pin.update(None).await.unwrap();
         assert_eq!(version, FileVersion {});
 
         let hashes = pin.fetch(&version).await.unwrap();
-        // Just verify we got a sha256 hash back
-        assert_eq!(hashes.hash.algo(), nix_compat::nixhash::HashAlgo::Sha256);
+        assert_eq!(
+            hashes.hash,
+            NixHash::from_sri("sha256-LJ3jc651pScWN2NQNERaXNOmrjWsbDBtQMDgZ2R4WJc=").unwrap(),
+        );
     }
 }

--- a/libnpins/src/file.rs
+++ b/libnpins/src/file.rs
@@ -1,7 +1,8 @@
 //! Pin a plain file URL source
 //!
-//! Uses `builtins.fetchurl` (or `pkgs.fetchurl` when nixpkgs is provided)
-//! to fetch a single file by URL and hash.
+//! Prefetches a single file via `nix-prefetch-url` and stores the resulting
+//! hash. The Nix side of the lockfile (see `default.nix`) consumes this with
+//! `fetchurl` to materialize the file.
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};

--- a/libnpins/src/file.rs
+++ b/libnpins/src/file.rs
@@ -1,0 +1,118 @@
+//! Pin a plain file URL source
+//!
+//! Uses `builtins.fetchurl` (or `pkgs.fetchurl` when nixpkgs is provided)
+//! to fetch a single file by URL and hash.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{GenericHash, Updatable, diff, nix};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub struct FilePin {
+    pub url: Url,
+}
+
+impl diff::Diff for FilePin {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![("url".into(), self.url.to_string())]
+    }
+}
+
+/// File pins have no meaningful version; the URL is assumed to be static.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct FileVersion {}
+
+impl diff::Diff for FileVersion {
+    fn properties(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+}
+
+#[async_trait::async_trait]
+impl Updatable for FilePin {
+    type Version = FileVersion;
+    type Hashes = GenericHash;
+
+    async fn update(&self, _old: Option<&FileVersion>) -> Result<FileVersion> {
+        Ok(FileVersion {})
+    }
+
+    async fn fetch(&self, _version: &FileVersion) -> Result<Self::Hashes> {
+        let hash = nix::nix_prefetch_url(&self.url).await?;
+        Ok(Self::Hashes { hash })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Frozen, GenericHash, NixPins, Pin};
+    use nix_compat::nixhash::NixHash;
+
+    #[test]
+    fn test_file_pin_roundtrip() {
+        let pins = NixPins {
+            pins: [(
+                "test-file".into(),
+                Pin::File {
+                    input: FilePin {
+                        url: "https://example.com/some-file.iso".parse().unwrap(),
+                    },
+                    version: Some(FileVersion {}),
+                    hashes: Some(GenericHash {
+                        hash: NixHash::from_sri(
+                            "sha256-K9yBph93OLTNw02Q6e9CYFGrUhvEXnh45vrZqIRWfvQ=",
+                        )
+                        .unwrap(),
+                    }),
+                    frozen: Frozen::default(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        };
+
+        let serialized = pins.to_value_versioned();
+        let deserialized = NixPins::from_json_versioned(serialized).unwrap();
+        assert_eq!(pins, deserialized);
+    }
+
+    #[test]
+    fn test_file_pin_serialization_shape() {
+        let pin = Pin::File {
+            input: FilePin {
+                url: "https://example.com/file.bin".parse().unwrap(),
+            },
+            version: Some(FileVersion {}),
+            hashes: Some(GenericHash {
+                hash: NixHash::from_sri("sha256-K9yBph93OLTNw02Q6e9CYFGrUhvEXnh45vrZqIRWfvQ=")
+                    .unwrap(),
+            }),
+            frozen: Frozen::default(),
+        };
+
+        let value = serde_json::to_value(&pin).unwrap();
+        assert_eq!(value["type"], "File");
+        assert_eq!(value["url"], "https://example.com/file.bin");
+        assert!(value["hash"].as_str().unwrap().starts_with("sha256-"));
+    }
+
+    #[tokio::test]
+    async fn test_file_update_and_fetch() {
+        // Use a small, stable file from the Nix cache
+        let pin = FilePin {
+            url: "https://raw.githubusercontent.com/NixOS/nixpkgs/master/README.md"
+                .parse()
+                .unwrap(),
+        };
+
+        let version = pin.update(None).await.unwrap();
+        assert_eq!(version, FileVersion {});
+
+        let hashes = pin.fetch(&version).await.unwrap();
+        // Just verify we got a sha256 hash back
+        assert_eq!(hashes.hash.algo(), nix_compat::nixhash::HashAlgo::Sha256);
+    }
+}

--- a/libnpins/src/lib.rs
+++ b/libnpins/src/lib.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 pub mod channel;
 pub mod container;
 pub mod diff;
+pub mod file;
 pub mod flake;
 pub mod git;
 pub mod niv;
@@ -291,6 +292,7 @@ mkPin! {
     (PyPi, pypi, "pypi package", pypi::Pin),
     (Channel, channel, "Nix channel", channel::Pin),
     (Tarball, tarball, "tarball", tarball::TarballPin),
+    (File, file, "file", file::FilePin),
     (Container, container, "OCI Container", container::Pin),
 }
 

--- a/libnpins/src/lib.rs
+++ b/libnpins/src/lib.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 pub mod channel;
 pub mod container;
 pub mod diff;
-pub mod file;
+pub mod fetchurl;
 pub mod flake;
 pub mod git;
 pub mod niv;
@@ -292,7 +292,7 @@ mkPin! {
     (PyPi, pypi, "pypi package", pypi::Pin),
     (Channel, channel, "Nix channel", channel::Pin),
     (Tarball, tarball, "tarball", tarball::TarballPin),
-    (File, file, "file", file::FilePin),
+    (Fetchurl, fetchurl, "fetchurl", fetchurl::FetchurlPin),
     (Container, container, "OCI Container", container::Pin),
 }
 

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -27,6 +27,7 @@ pub async fn nix_prefetch_url(url: impl AsRef<str>) -> Result<NixHash> {
             .await
             .with_context(|| format!("Failed to spawn nix-prefetch-url for {}", url))?;
 
+        // FIXME: handle errors and pipe stderr through
         if !output.status.success() {
             return Err(anyhow::anyhow!(format!(
                 "failed to prefetch url: {}\n{}",
@@ -35,9 +36,13 @@ pub async fn nix_prefetch_url(url: impl AsRef<str>) -> Result<NixHash> {
             )));
         }
 
+        // try to parse the returned hash.
         let hash_str = std::str::from_utf8(&output.stdout)
             .with_context(|| "nix-prefetch-url sent invalid utf8")?
+            // Trim, otherwise the call to `from_nix_nixbase32` will fail due to newline
             .trim();
+        // FIXME: nix-compat expects nixbase32-encoded string in format "alg:digest", but
+        // `nix-prefetch-url` gives digest only. Gross way to do this is to specify alg manually
         let annotated_nix32_hash = format!("sha256:{hash_str}");
         NixHash::from_nix_nixbase32(&annotated_nix32_hash)
             .with_context(|| format!("failed to convert {} to NixHash", hash_str))

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -13,13 +13,11 @@ pub struct PrefetchInfo {
 pub async fn nix_prefetch_url(url: impl AsRef<str>) -> Result<NixHash> {
     let url = url.as_ref();
     let result = async {
-        log::debug!(
-            "Executing `nix-prefetch-url --name source --type sha256 {}`",
-            url
-        );
+        log::debug!("Executing `nix-prefetch-url --type sha256 {}`", url);
+        // No `--name` is passed, so `nix-prefetch-url` derives the store path name from the URL's
+        // basename. This matches the default behavior of `builtins.fetchurl` / `pkgs.fetchurl`
+        // (as used by `mkFileSource`), so the file is not downloaded twice.
         let output = tokio::process::Command::new("nix-prefetch-url")
-            .arg("--name")
-            .arg("source")
             .arg("--type")
             .arg("sha256")
             .arg(url)

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -10,6 +10,41 @@ pub struct PrefetchInfo {
     hash: String,
 }
 
+pub async fn nix_prefetch_url(url: impl AsRef<str>) -> Result<NixHash> {
+    let url = url.as_ref();
+    let result = async {
+        log::debug!(
+            "Executing `nix-prefetch-url --name source --type sha256 {}`",
+            url
+        );
+        let output = tokio::process::Command::new("nix-prefetch-url")
+            .arg("--name")
+            .arg("source")
+            .arg("--type")
+            .arg("sha256")
+            .arg(url)
+            .output()
+            .await
+            .with_context(|| format!("Failed to spawn nix-prefetch-url for {}", url))?;
+
+        if !output.status.success() {
+            return Err(anyhow::anyhow!(format!(
+                "failed to prefetch url: {}\n{}",
+                url,
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        let hash_str = std::str::from_utf8(&output.stdout)
+            .with_context(|| "nix-prefetch-url sent invalid utf8")?
+            .trim();
+        let annotated_nix32_hash = format!("sha256:{hash_str}");
+        NixHash::from_nix_nixbase32(&annotated_nix32_hash)
+            .with_context(|| format!("failed to convert {} to NixHash", hash_str))
+    };
+    check_url(result.await, url).await
+}
+
 pub async fn nix_prefetch_tarball(url: impl AsRef<str>) -> Result<NixHash> {
     let url = url.as_ref();
     let result = async {

--- a/libnpins/src/versions.rs
+++ b/libnpins/src/versions.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeMap, path::Path};
 use crate::NixPins;
 
 /// The current format version
-pub const LATEST: u64 = 7;
+pub const LATEST: u64 = 8;
 
 /// Custom manual deserialize wrapper that checks the version
 pub fn from_value_versioned(value: Value) -> Result<NixPins> {

--- a/npins/default.nix
+++ b/npins/default.nix
@@ -242,7 +242,7 @@ mkFunctor (
         throw "Unsupported input type ${builtins.typeOf input}, must be a path or an attrset";
     version = data.version;
   in
-  if version == 7 then
+  if version == 8 then
     builtins.mapAttrs (name: spec: mkFunctor (mkSource name spec)) data.pins
   else
     throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -27,5 +27,5 @@
       "hash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU="
     }
   },
-  "version": 7
+  "version": 8
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,6 +357,19 @@ impl TarballAddOpts {
     }
 }
 
+#[derive(Debug, Parser)]
+pub struct FileAddOpts {
+    /// File URL
+    pub url: Url,
+}
+
+impl FileAddOpts {
+    pub fn add(&self) -> Result<(Option<String>, Pin)> {
+        let url = self.url.clone();
+        Ok((None, file::FilePin { url }.into()))
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum AddCommands {
     /// Track a Nix channel
@@ -386,6 +399,12 @@ pub enum AddCommands {
     /// URL which supports flakes "Lockable HTTP Tarball" API.
     #[command(name = "tarball")]
     Tarball(TarballAddOpts),
+    /// Track a file download
+    ///
+    /// Tracks a plain file URL. Unlike tarball, this fetches a single file
+    /// without unpacking. Useful for e.g. ISO images or individual files.
+    #[command(name = "file")]
+    File(FileAddOpts),
 }
 
 #[derive(Debug, Parser)]
@@ -414,6 +433,7 @@ impl AddOpts {
             AddCommands::GitLab(gl) => gl.add()?,
             AddCommands::PyPi(p) => p.add()?,
             AddCommands::Tarball(p) => p.add()?,
+            AddCommands::File(p) => p.add()?,
             AddCommands::Container(p) => p.add()?,
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,15 +358,15 @@ impl TarballAddOpts {
 }
 
 #[derive(Debug, Parser)]
-pub struct FileAddOpts {
+pub struct FetchurlAddOpts {
     /// File URL
     pub url: Url,
 }
 
-impl FileAddOpts {
+impl FetchurlAddOpts {
     pub fn add(&self) -> Result<(Option<String>, Pin)> {
         let url = self.url.clone();
-        Ok((None, file::FilePin { url }.into()))
+        Ok((None, fetchurl::FetchurlPin { url }.into()))
     }
 }
 
@@ -399,12 +399,12 @@ pub enum AddCommands {
     /// URL which supports flakes "Lockable HTTP Tarball" API.
     #[command(name = "tarball")]
     Tarball(TarballAddOpts),
-    /// Track a file download
+    /// Track a plain file download
     ///
     /// Tracks a plain file URL. Unlike tarball, this fetches a single file
     /// without unpacking. Useful for e.g. ISO images or individual files.
-    #[command(name = "file")]
-    File(FileAddOpts),
+    #[command(name = "fetchurl")]
+    Fetchurl(FetchurlAddOpts),
 }
 
 #[derive(Debug, Parser)]
@@ -433,7 +433,7 @@ impl AddOpts {
             AddCommands::GitLab(gl) => gl.add()?,
             AddCommands::PyPi(p) => p.add()?,
             AddCommands::Tarball(p) => p.add()?,
-            AddCommands::File(p) => p.add()?,
+            AddCommands::Fetchurl(p) => p.add()?,
             AddCommands::Container(p) => p.add()?,
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,10 +399,14 @@ pub enum AddCommands {
     /// URL which supports flakes "Lockable HTTP Tarball" API.
     #[command(name = "tarball")]
     Tarball(TarballAddOpts),
-    /// Track a plain file download
+    /// Pin a file through a URL
     ///
-    /// Tracks a plain file URL. Unlike tarball, this fetches a single file
-    /// without unpacking. Useful for e.g. ISO images or individual files.
+    /// Pins a plain file through a URL. There is no additional processing
+    /// for the URL, redirects are followed at download time but not tracked.
+    /// There is no further processing of the downloaded artifact.
+    /// Unlike e.g. tarball, this fetches a single file without unpacking.
+    /// Useful for unchanging static assets e.g. ISO images or any other
+    /// individual files.
     #[command(name = "fetchurl")]
     Fetchurl(FetchurlAddOpts),
 }

--- a/test.nix
+++ b/test.nix
@@ -299,6 +299,51 @@ let
         touch $out
       '';
 
+  mkFetchurlTest =
+    {
+      name,
+      commands,
+      files,
+    }:
+    pkgs.runCommand name
+      {
+        nativeBuildInputs = with pkgs; [
+          npins
+          python3
+          netcat
+          lix
+          jq
+        ];
+      }
+      ''
+        set -euo pipefail
+        source ${prelude}
+
+        echo -e "\n\nRunning test ${name}\n"
+        cd $(mktemp -d)
+        export SSL_CERT_FILE=${./tests/assets/cert.pem}
+
+        # Create files to serve. Each attribute maps a served path to its
+        # contents so that `fetchurl` pins can be pointed at a known byte
+        # stream with a predictable hash.
+        ${lib.pipe files [
+          (lib.mapAttrsToList (
+            path: contents: ''
+              mkdir -p $(dirname ${path})
+              printf '%s' ${lib.escapeShellArg contents} > ${path}
+            ''
+          ))
+          (lib.concatStringsSep "\n")
+        ]}
+
+        python -m http.server 8000 &
+        timeout 30 sh -c 'set -e; until nc -z 127.0.0.1 8000; do sleep 1; done' || exit 1
+
+        ${commands}
+
+        touch $out
+      '';
+
   mkGithubTest =
     {
       name,
@@ -810,6 +855,31 @@ in
       eq "$(jq -r .pins.foo2.revision npins/sources.json)" "$(resolveGitCommit ${repositories."owner/foo"})"
       eq "$(jq -r .pins.foo.url npins/sources.json)" "http://localhost:8000/owner/foo/archive/$(resolveGitCommit ${repositories."owner/foo"}).tar.gz"
       eq "$(jq -r .pins.foo2.url npins/sources.json)" "null"
+    '';
+  };
+
+  fetchurl = mkFetchurlTest {
+    name = "fetchurl";
+    files."file.txt" = "hello npins\n";
+    commands = ''
+      npins init --bare
+      npins add --name file fetchurl http://localhost:8000/file.txt
+      npins show
+
+      # The lockfile records the URL and a non-null hash.
+      eq "$(jq -r .pins.file.type npins/sources.json)" "Fetchurl"
+      eq "$(jq -r .pins.file.url npins/sources.json)" "http://localhost:8000/file.txt"
+      neq "$(jq -r .pins.file.hash npins/sources.json)" "null"
+
+      # The Nix side can consume the pin and produce a store path.
+      nix-instantiate --eval npins -A file.outPath
+
+      # `update` is idempotent: url and hash stay the same.
+      url_before=$(jq -r .pins.file.url npins/sources.json)
+      hash_before=$(jq -r .pins.file.hash npins/sources.json)
+      npins update file
+      eq "$(jq -r .pins.file.url npins/sources.json)" "$url_before"
+      eq "$(jq -r .pins.file.hash npins/sources.json)" "$hash_before"
     '';
   };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -62,8 +62,8 @@ let
           mkChannelSource spec
         else if spec.type == "Tarball" then
           mkTarballSource spec
-        else if spec.type == "File" then
-          mkFileSource spec
+        else if spec.type == "Fetchurl" then
+          mkFetchurlSource spec
         else if spec.type == "Container" then
           mkContainerSource spec
         else
@@ -153,7 +153,7 @@ let
       sha256 = hash;
     };
 
-  mkFileSource =
+  mkFetchurlSource =
     {
       url,
       hash,

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -62,6 +62,8 @@ let
           mkChannelSource spec
         else if spec.type == "Tarball" then
           mkTarballSource spec
+        else if spec.type == "File" then
+          mkFileSource spec
         else if spec.type == "Container" then
           mkContainerSource spec
         else
@@ -148,6 +150,17 @@ let
     }:
     builtins.fetchTarball {
       url = locked_url;
+      sha256 = hash;
+    };
+
+  mkFileSource =
+    {
+      url,
+      hash,
+      ...
+    }:
+    builtins.fetchurl {
+      inherit url;
       sha256 = hash;
     };
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -164,7 +164,7 @@ let
       finalImageTag = image_tag;
     };
 in
-if version == 7 then
+if version == 8 then
   builtins.mapAttrs mkSource data.pins
 else
   throw "Unsupported format version ${toString version} in sources.json. Try running `npins upgrade`"

--- a/tests/sources.json
+++ b/tests/sources.json
@@ -39,6 +39,11 @@
       "url": "https://files.pythonhosted.org/packages/f0/46/9b3f73886f82d27849ce1e7a74ae7c39f5323e46da0b6e8847ad4c25f44c/streamlit-1.45.1.tar.gz",
       "hash": "sha256-431WwK9SQNvCQJdogOgTZmicKQpVk3ZBckb5s/UbQhc="
     },
+    "nixpkgs-license": {
+      "type": "File",
+      "url": "https://raw.githubusercontent.com/NixOS/nixpkgs/6afe187897bef7933475e6af374c893f4c84a293/COPYING",
+      "hash": "sha256-sSacq4xzmkm0HH+JpnmAWyAPJoJG/p7gd8kdp4tgL54="
+    },
     "ubuntu": {
       "type": "Container",
       "image_name": "ubuntu",

--- a/tests/sources.json
+++ b/tests/sources.json
@@ -63,5 +63,5 @@
       "hash": "sha256-hwtdYYyCxDEs5OrTo0BbAuww3hjzEaQ+R/ABfEyXFCg="
     }
   },
-  "version": 7
+  "version": 8
 }

--- a/tests/sources.json
+++ b/tests/sources.json
@@ -40,7 +40,7 @@
       "hash": "sha256-431WwK9SQNvCQJdogOgTZmicKQpVk3ZBckb5s/UbQhc="
     },
     "nixpkgs-license": {
-      "type": "File",
+      "type": "Fetchurl",
       "url": "https://raw.githubusercontent.com/NixOS/nixpkgs/6afe187897bef7933475e6af374c893f4c84a293/COPYING",
       "hash": "sha256-sSacq4xzmkm0HH+JpnmAWyAPJoJG/p7gd8kdp4tgL54="
     },


### PR DESCRIPTION
Implements support for tracking arbitrary file downloads (non-tarball). Uses `pkgs.fetchurl to fetch a single file by URL and hash, without unpacking.

Usage: `npins add file <url>`

closes: #163.

disclaimer i used a coding agent in the creation of this patch.
