### PR TITLE
Show forge compare URLs on update

### DIFF
--- a/libnpins/src/diff.rs
+++ b/libnpins/src/diff.rs
@@ -10,6 +10,16 @@ pub enum Change {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DiffEntry(String, Change);
 
+impl DiffEntry {
+    pub fn key(&self) -> &str {
+        &self.0
+    }
+
+    pub fn change(&self) -> &Change {
+        &self.1
+    }
+}
+
 impl std::fmt::Display for DiffEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let DiffEntry(property, change) = self;

--- a/libnpins/src/git.rs
+++ b/libnpins/src/git.rs
@@ -419,6 +419,27 @@ impl Repository {
             },
         })
     }
+
+    /// Get a URL to compare two revisions on the forge's web UI
+    ///
+    /// Returns `None` for plain git repositories without a known forge.
+    pub fn compare_url(&self, old: &str, new: &str) -> Option<String> {
+        match self {
+            Repository::Git { .. } => None,
+            Repository::GitHub { owner, repo } => Some(format!(
+                "{github}/{owner}/{repo}/compare/{old}...{new}",
+                github = get_github_url(),
+            )),
+            Repository::Forgejo {
+                server,
+                owner,
+                repo,
+            } => Some(format!("{server}{owner}/{repo}/compare/{old}...{new}")),
+            Repository::GitLab {
+                repo_path, server, ..
+            } => Some(format!("{server}{repo_path}/-/compare?from={old}&to={new}")),
+        }
+    }
 }
 
 /// Track a given branch on a repository and always use the latest commit

--- a/libnpins/src/lib.rs
+++ b/libnpins/src/lib.rs
@@ -294,6 +294,35 @@ mkPin! {
     (Container, container, "OCI Container", container::Pin),
 }
 
+impl Pin {
+    /// Generate a forge compare URL from diff entries, if the pin is git-based
+    ///
+    /// For Git pins, compares revisions. For GitRelease pins, compares version tags.
+    pub fn compare_url(&self, diff: &[diff::DiffEntry]) -> Option<String> {
+        let repository = match self {
+            Pin::Git { input, .. } => &input.repository,
+            Pin::GitRelease { input, .. } => &input.repository,
+            _ => return None,
+        };
+
+        let key = match self {
+            Pin::Git { .. } => "revision",
+            Pin::GitRelease { .. } => "version",
+            _ => return None,
+        };
+
+        for entry in diff {
+            if entry.key() == key {
+                if let diff::Change::Changed(old, new) = entry.change() {
+                    return repository.compare_url(old, new);
+                }
+            }
+        }
+
+        None
+    }
+}
+
 /// The main struct the CLI operates on
 ///
 /// For serialization purposes, use the `NixPinsVersioned` wrapper instead.

--- a/src/main.rs
+++ b/src/main.rs
@@ -590,13 +590,16 @@ pub struct Opts {
     command: Command,
 }
 
-fn write_diff(writer: &mut impl Write, name: &str, diff: &[diff::DiffEntry]) {
+fn write_diff(writer: &mut impl Write, name: &str, pin: &Pin, diff: &[diff::DiffEntry]) {
     if diff.is_empty() {
         writeln!(writer, "[{name}] No Changes").unwrap();
     } else {
         writeln!(writer, "[{name}] Changes:").unwrap();
         for entry in diff {
             write!(writer, "{entry}").unwrap();
+        }
+        if let Some(url) = pin.compare_url(diff) {
+            writeln!(writer, "     compare: {url}").unwrap();
         }
     }
 }
@@ -839,7 +842,7 @@ impl Opts {
             .map(|(name, pin)| async move {
                 animation.on_pin_start(name);
                 let diff = Self::update_one(name, pin, strategy).await?;
-                animation.on_pin_finish(name, |stderr| write_diff(stderr, name, &diff));
+                animation.on_pin_finish(name, |stderr| write_diff(stderr, name, pin, &diff));
                 anyhow::Result::<_, anyhow::Error>::Ok((name, diff))
             });
 
@@ -913,7 +916,7 @@ impl Opts {
                 animation.on_pin_start(name);
                 let diff_result = Self::update_one(name, pin, STRATEGY).await;
                 animation.on_pin_finish(name, |stderr| match &diff_result {
-                    Ok(diff) => write_diff(stderr, name, diff),
+                    Ok(diff) => write_diff(stderr, name, pin, diff),
                     Err(err) => {
                         writeln!(stderr, "[{name}] Failed download").unwrap();
                         writeln!(stderr, "{err:?}").unwrap();


### PR DESCRIPTION
When a git-based pin changes, print a link to the forge's compare view (e.g. GitHub/Forgejo `/compare/old...new`, GitLab `/-/compare`) so users can quickly review upstream changes.

closes #177.

dsisclaimer i used a coding agent in the creation of this patch.
