### PR TITLE
CI: Also try macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.3
       - uses: samueldr/lix-gha-installer-action@8dc19fbd6451fa106a68ecb2dafeeeb90dff3a29 # latest @ 2025-02-28

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - macos-26-intel
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,5 @@ jobs:
       - name: Run smoke test
         run: nix-shell --run "bash ./.github/workflows/smoke-test.sh"
       - name: Run integration tests
+        if: ${{ runner.os == 'Linux' }}
         run: nix-build -A meta.tests


### PR DESCRIPTION
Both `x86_64` and `aarch64`.

This either is going to be a pain and will be commented soon enough after introduction, at which point we'll know. Or it'll be useful to keep tabs on the build status for macOS.

CC @andir; I'm guessing since [it's only been a couple of months](https://github.com/andir/npins/commit/b6f34245408412ec7a3ef022d583a08ed937868d), that you're still (un)fortunate enough to be using macOS at work, right? That might be useful for you then.

This might also help with getting PRs like #80 over the hump, in the future, if ever needed.

~~(Initially opened as draft, as GitHub's macOS is still running on my test branch, I'm impatient, and foolishly confident.)~~