### PR TITLE
Reduce boilerplate around verbosely-logged commands, and unify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "shlex",
  "tokio",
  "url",
 ]

--- a/libnpins/Cargo.toml
+++ b/libnpins/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1"
 lenient_semver_parser = { version = "0.4.2", default-features = false }
 lenient_version = { version = "0.4.2" }
 nix-compat = { git = "https://git.snix.dev/snix/snix", rev = "4918571f95d436d2e3da4665e8c1e9b77d9546e8", default-features = false, features = ["serde"] }
+shlex = "1.3.0"
 
 [dev-dependencies]
 env_logger = { version = "^0.11.0", features = ["color", "auto-color", "regex"], default-features = false }

--- a/libnpins/src/git.rs
+++ b/libnpins/src/git.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use url::Url;
 
-use crate::{GenericVersion, Updatable, check_git_url, diff, get_and_deserialize, nix};
+use crate::{
+    GenericVersion, Updatable, check_git_url, diff, format_command, get_and_deserialize, nix,
+};
 
 fn get_github_url() -> String {
     std::env::var("NPINS_GITHUB_HOST").unwrap_or_else(|_| String::from("https://github.com"))
@@ -683,13 +685,17 @@ impl RemoteInfo {
 /// Convenience wrapper around calling `git ls-remote`
 async fn fetch_remote(url: &str, args: &[&str]) -> Result<Vec<RemoteInfo>> {
     let result = async {
-        log::debug!("Executing `git ls-remote {}`", args.join(" "));
-        let process = Command::new("git")
+        let mut command = Command::new("git");
+        command
             // Disable any interactive login attempts, failing gracefully instead
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=yes")
             .arg("ls-remote")
-            .args(args)
+            .args(args);
+
+        log::debug!("Executing: {}", format_command(&command)?);
+
+        let process = command
             .output()
             .await
             .context("Failed waiting for git ls-remote subprocess")?;

--- a/libnpins/src/lib.rs
+++ b/libnpins/src/lib.rs
@@ -393,6 +393,82 @@ impl diff::Diff for GenericUrlHashes {
     }
 }
 
+fn elide_to_first_line(input_string: &str) -> String {
+    let mut lines = input_string.lines();
+    let value = lines.next().unwrap_or("(unknown)");
+
+    // Add the ellipsis at the end of the string if needed.
+    match lines.next() {
+        // Only one line.
+        None => value.to_string(),
+        // Multi-line
+        Some(_) => {
+            format!("{}…", value)
+        },
+    }
+}
+
+/// Formats a command in a shell-safe manner.
+///
+/// NOTE: Multi-line components will be elided to their first line!
+pub(crate) fn format_command(tokio_cmd: &tokio::process::Command) -> anyhow::Result<String> {
+    // `tokio::process`'s `Command` doesn't allow introspecting, so let's ignore that
+    // and use it as a `std::process::Command`.
+    let cmd = tokio_cmd.as_std();
+
+    let mut command_parts: Vec<String> = Vec::new();
+
+    // Format and escape environment
+    let envs: Vec<String> =
+        cmd.get_envs()
+            .map(|(name, value)| {
+                let value = elide_to_first_line(
+                value
+                .expect("Environment variable for command should have an environment variable name")
+                .to_str()
+                .unwrap_or("(unknown)")
+            );
+
+                // Escape the value only.
+                let value = shlex::try_quote(&value).unwrap_or("(invalid)".into());
+
+                // The escaping would produce 'NAME=VA LUE', which will not produce a strings that can
+                // be used for passing an environment variables to a command.
+                let name = name.to_str().unwrap_or("(unknown)");
+
+                format!("{}={}", name, value)
+            })
+            .collect();
+
+    // Add to the command
+    command_parts.extend(envs);
+
+    // Use the basename of the command.
+    let exe_name = std::path::Path::new(cmd.get_program())
+        .file_name()
+        .unwrap_or(std::ffi::OsStr::new("(unknown)"))
+        .to_str()
+        .unwrap_or("(unknown)");
+
+    command_parts.push(exe_name.into());
+
+    // Escape all args
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|s| {
+            let arg = s.to_str().unwrap_or("(unknown)");
+            shlex::try_quote(&elide_to_first_line(arg))
+                .unwrap_or("(invalid)".into())
+                .into()
+        })
+        .collect();
+
+    // Add to the command
+    command_parts.extend(args);
+
+    Ok(command_parts.join(" "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -197,10 +197,8 @@ pub async fn nix_eval_pin(lockfile_path: &Path, pin: &str) -> Result<std::path::
     let nix_eval_code =
         format!("{{pin, path}}: (({DEFAULT_NIX}) {{ input = /. + path; }}).${{pin}}.outPath");
 
-    log::debug!(
-        "Executing: `nix-instantiate --eval --json --expr '{{pin}}: (import default.nix).${{pin}}.outPath' --argstr pin '{pin}' --argstr path '{{«snip»}}'`",
-    );
-    let output = tokio::process::Command::new("nix-instantiate")
+    let mut command = tokio::process::Command::new("nix-instantiate");
+    command
         .arg("--show-trace")
         .arg("--eval")
         .arg("--json")
@@ -211,7 +209,11 @@ pub async fn nix_eval_pin(lockfile_path: &Path, pin: &str) -> Result<std::path::
         .arg(pin)
         .arg("--argstr")
         .arg("path")
-        .arg(lockfile_path)
+        .arg(lockfile_path);
+
+    log::debug!("Executing: {}", format_command(&command)?);
+
+    let output = command
         .stdout(std::process::Stdio::piped())
         .spawn()
         .context("Failed to spawn `nix-instantiate`")?

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -60,35 +60,26 @@ pub async fn nix_prefetch_git(
     let url = url.as_ref();
 
     let result = async {
-        log::debug!(
-            "Executing: `nix-prefetch-git {}{} {}`",
-            if submodules {
-                "--fetch-submodules "
-            } else {
-                ""
-            },
-            url,
-            git_ref.as_ref()
-        );
-        let mut output = tokio::process::Command::new("nix-prefetch-git");
+        let mut command = tokio::process::Command::new("nix-prefetch-git");
         if submodules {
-            output.arg("--fetch-submodules");
+            command.arg("--fetch-submodules");
         }
-        let output = output
+        command
             // Disable any interactive login attempts, failing gracefully instead
             .env("GIT_TERMINAL_PROMPT", "0")
             .env("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=yes")
             .arg(url)
-            .arg(git_ref.as_ref())
-            .output()
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to spawn nix-prefetch-git for {} @ {}",
-                    url,
-                    git_ref.as_ref()
-                )
-            })?;
+            .arg(git_ref.as_ref());
+
+        log::debug!("Executing: {}", format_command(&command)?);
+
+        let output = command.output().await.with_context(|| {
+            format!(
+                "Failed to spawn nix-prefetch-git for {} @ {}",
+                url,
+                git_ref.as_ref()
+            )
+        })?;
 
         // FIXME: handle errors and pipe stderr through
         if !output.status.success() {

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -141,26 +141,20 @@ pub async fn nix_prefetch_docker(
     let image_name = image_name.as_ref();
     let image_tag = image_tag.as_ref();
 
-    log::debug!(
-        "Executing: `nix-prefetch-docker {} {}{}`",
-        image_name,
-        image_tag,
-        match image_digest {
-            Some(x) => format!(" --image-digest {}", x),
-            None => "".into(),
-        }
-    );
-    let mut output = tokio::process::Command::new("nix-prefetch-docker");
-    let output = output
+    let mut command = tokio::process::Command::new("nix-prefetch-docker");
+    command
         .arg(image_name)
         .arg(image_tag)
         .arg("--json")
         .arg("--quiet");
-    let output = match image_digest {
-        Some(x) => output.arg("--image-digest").arg(x),
-        None => output,
-    };
-    let output = output.output().await.with_context(|| {
+
+    if let Some(value) = image_digest {
+        command.arg("--image-digest").arg(value);
+    }
+
+    log::debug!("Executing: {}", format_command(&command)?);
+
+    let output = command.output().await.with_context(|| {
         format!(
             "Failed to spawn nix-prefetch-docker for {}:{}",
             image_name, image_tag

--- a/libnpins/src/nix.rs
+++ b/libnpins/src/nix.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use nix_compat::nixhash::{HashAlgo, NixHash};
 use std::path::Path;
 
-use crate::{DEFAULT_NIX, check_git_url, check_url};
+use crate::{DEFAULT_NIX, check_git_url, check_url, format_command};
 
 #[allow(unused)]
 pub struct PrefetchInfo {
@@ -13,17 +13,18 @@ pub struct PrefetchInfo {
 pub async fn nix_prefetch_tarball(url: impl AsRef<str>) -> Result<NixHash> {
     let url = url.as_ref();
     let result = async {
-        log::debug!(
-            "Executing `nix-prefetch-url --unpack --name source --type sha256 {}`",
-            url
-        );
-        let output = tokio::process::Command::new("nix-prefetch-url")
+        let mut command = tokio::process::Command::new("nix-prefetch-url");
+        command
             .arg("--unpack") // force calculation of the unpacked NAR hash
             .arg("--name")
             .arg("source") // use the same symbolic store path name as `builtins.fetchTarball` to avoid downloading the source twice
             .arg("--type")
             .arg("sha256")
-            .arg(url)
+            .arg(url);
+
+        log::debug!("Executing: {}", format_command(&command)?);
+
+        let output = command
             .output()
             .await
             .with_context(|| format!("Failed to spawn nix-prefetch-url for {}", url))?;


### PR DESCRIPTION
Drafted since there are FIXMEs regarding idiomatic Rust stuff, some little work items, and because of the likely clash with what @piegamesde was working on yesterday.

I'm looking for comments regarding if this is desirable first, and then some comments regarding my mishandling of Rust.

I'm also open for opinions or thoughts regarding the "API design" used here. I don't know if there's any way to make this much more handy to use with the way a `tokio::process::Command` works, or even idiomatic Rust..

* * *

The rationale for these changes is, first, how awful it is to go through code that half-duplicates the approximate same ways to print the command that is being ran, but with small details like adding spaces to the arguments conditionally so the command is pretty printed nicely.

And then seeing that at least `nix_eval_pin` had drifted from the actual command being ran.

So instead, let's use a function that *formats* a `tokio::process::Command`, such that it is impossible for it to be incorrect\*

\* It will be "incorrect" for multi-line arguments in its initial draft, by design.

Additionally, this is going through `shlex` for escaping the printed arguments. This should *help* ensuring the commands as-printed can be ran by the ed-user. (Note that I won't claim any safety guarantee, but `shlex` [makes some claims](https://docs.rs/shlex/latest/shlex/).) For this usage, this is for convenience.

Disclaimer: I write my own code. All mistakes are handcrafted with love.