### PR TITLE
check_url skip non-http(s) URLs and add response error as context

### DIFF
--- a/libnpins/src/lib.rs
+++ b/libnpins/src/lib.rs
@@ -3,11 +3,13 @@
 //! Currently, it pretty much exposes the internals of the CLI 1:1, but in the future
 //! this is supposed to evolve into a more standalone library.
 
+use anyhow::Context;
 use diff::{Diff, OptionExt};
 use nix_compat::nixhash::NixHash;
 use reqwest::IntoUrl;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use url::Url;
 
 pub mod pins;
 pub use pins::*;
@@ -57,16 +59,26 @@ where
 /// If `result` is `Ok`, it is passed on unchanged and nothing is done.
 /// If `result` is `Err`, the check will be executed and the error replaced in case of failure.
 async fn check_url<T>(result: anyhow::Result<T>, url: &str) -> anyhow::Result<T> {
-    if result.is_err() {
-        log::debug!("Checking {url}");
-        /* Note that *in theory* we should be able to use a HEAD request instead of GET, however
-         * several HTTP servers don't comply with that so we have to GET and then throw away the content instead.
-         * Some return 405 Method Not Allowed which would be fine, however GitLab for example simply returns
-         * 403 Forbidden on HEAD for an URL that is 200 on GET.
-         */
-        build_client()?.get(url).send().await?.error_for_status()?;
+    if result.is_ok() {
+        return result;
     }
-    result
+
+    let url: Url = url.parse()?;
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return result;
+    }
+
+    log::debug!("Checking {url}");
+    /* Note that *in theory* we should be able to use a HEAD request instead of GET, however
+     * several HTTP servers don't comply with that so we have to GET and then throw away the content instead.
+     * Some return 405 Method Not Allowed which would be fine, however GitLab for example simply returns
+     * 403 Forbidden on HEAD for an URL that is 200 on GET.
+     */
+    let Err(response_error) = build_client()?.get(url).send().await?.error_for_status() else {
+        return result;
+    };
+
+    result.context(response_error)
 }
 
 /// The git url to a repo has no defined endpoint in the protocol, and thus


### PR DESCRIPTION
This fixes a issue @blokyk hit where she saw a error returned from reqwest about a incorrect URL scheme instead of the actual error returned by the nix command. 

Nix errors will also be shown even for http/https URLs since I think the extra verbosity is fine, here is what a couple of errors look like now with it:
```
[INFO ] Adding 'lix a' …
Error: Failed to fully initialize the pin

Caused by:
    0: Fetching lix a
    1: HTTP status client error (404 Not Found) for url (https://git.lix.systems/lix-project/lix/archive/release-2.93s.tar.gz)
    2: failed to prefetch url: https://git.lix.systems/lix-project/lix/archive/release-2.93s.tar.gz
       error: unable to download 'https://git.lix.systems/lix-project/lix/archive/release-2.93s.tar.gz': HTTP error 404 ()
       
              response body:
       
              unrecognized repository reference: release-2.93s
```
```
[INFO ] Auto-detected Forgejo repository (git.lix.systems)
[INFO ] Adding 'lix-module' …
Error: Failed to fully initialize the pin

Caused by:
    0: Updating lix-module
    1: Couldn't fetch the latest commit
    2: Failed to get revision from remote for https://git.lix.systems/lix-project/nixos-modules.git refs/heads/main
    3: HTTP status client error (401 Unauthorized) for url (https://git.lix.systems/lix-project/nixos-modules.git/info/refs?service=git-upload-pack)
    4: git ls-remote failed with exit code 128
       remote: Unauthorized
       fatal: Authentication failed for 'https://git.lix.systems/lix-project/nixos-modules.git/'
```

A extra error at the end is _probably_ fine.