### PR TITLE
feat: add git-lfs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ Options:
       --submodules
           Also fetch submodules
 
+      --lfs
+          Also fetch LFS references
+
   -h, --help
           Print help (see a summary with '-h')
 ```
@@ -317,10 +320,10 @@ Options:
 $ npins help remove
 Removes one pin entry
 
-Usage: npins remove [OPTIONS] [NAMES]...
+Usage: npins remove [OPTIONS] <NAMES>...
 
 Arguments:
-  [NAMES]...  
+  <NAMES>...  
 
 Options:
   -v, --verbose  Print debug messages

--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -139,7 +139,7 @@ let
     assert repository ? type;
     # At the moment, either it is a plain git repository (which has an url), or it is a GitHub/GitLab repository
     # In the latter case, there we will always be an url to the tarball
-    if url != null && !submodules then
+    if url != null && !submodules && !lfs then
       fetchTarball {
         inherit url;
         sha256 = hash;

--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -88,10 +88,16 @@ let
                 submodules,
                 rev,
                 name,
+                lfs,
                 narHash,
               }:
               pkgs.fetchgit {
-                inherit url rev name;
+                inherit
+                  url
+                  rev
+                  name
+                  lfs
+                  ;
                 fetchSubmodules = submodules;
                 hash = narHash;
               };
@@ -127,6 +133,7 @@ let
       url ? null,
       submodules,
       hash,
+      lfs,
       ...
     }:
     assert repository ? type;
@@ -166,7 +173,12 @@ let
         rev = revision;
         narHash = hash;
 
-        inherit name submodules url;
+        inherit
+          name
+          submodules
+          url
+          lfs
+          ;
       };
 
   mkPyPiSource =

--- a/libnpins/src/flake.rs
+++ b/libnpins/src/flake.rs
@@ -93,6 +93,7 @@ impl FlakePin {
                     ),
                     branch,
                     false,
+                    false,
                 )
                 .into()
             },
@@ -109,6 +110,7 @@ impl FlakePin {
                     ),
                     branch,
                     false,
+                    false,
                 )
                 .into()
             },
@@ -122,6 +124,7 @@ impl FlakePin {
                         self.locked.url.context("missing url on git flake input")?,
                     ),
                     ref_,
+                    false,
                     false,
                 )
                 .into()

--- a/libnpins/src/niv.rs
+++ b/libnpins/src/niv.rs
@@ -23,12 +23,17 @@ impl TryFrom<NivPin> for Pin {
 
     fn try_from(niv: NivPin) -> anyhow::Result<Self> {
         Ok(match niv.owner {
-            None => {
-                git::GitPin::new(git::Repository::git(niv.repo.parse()?), niv.branch, false).into()
-            },
+            None => git::GitPin::new(
+                git::Repository::git(niv.repo.parse()?),
+                niv.branch,
+                false,
+                false,
+            )
+            .into(),
             Some(owner) => git::GitPin::new(
                 git::Repository::github(&owner, &niv.repo),
                 niv.branch,
+                false,
                 false,
             )
             .into(),

--- a/libnpins/src/pins/git.rs
+++ b/libnpins/src/pins/git.rs
@@ -445,6 +445,7 @@ impl diff::Diff for GitPin {
             ),
             ("branch".into(), self.branch.clone()),
             ("submodules".into(), self.submodules.to_string()),
+            ("lfs".into(), self.lfs.to_string()),
         ]
     }
 }
@@ -529,6 +530,9 @@ pub struct GitReleasePin {
     /// Also fetch submodules
     #[serde(default)]
     pub submodules: bool,
+    /// Also fetch LFS references
+    #[serde(default)]
+    pub lfs: bool,
 }
 
 impl diff::Diff for GitReleasePin {
@@ -548,6 +552,7 @@ impl diff::Diff for GitReleasePin {
                 .as_ref()
                 .map(|release_prefix| ("release_prefix".into(), release_prefix.clone())),
             Some(("submodules".into(), self.submodules.to_string())),
+            Some(("lfs".into(), self.lfs.to_string())),
         ]
         .into_iter()
         .flat_map(Option::into_iter)
@@ -562,6 +567,7 @@ impl GitReleasePin {
         version_upper_bound: Option<String>,
         release_prefix: Option<String>,
         submodules: bool,
+        lfs: bool,
     ) -> Self {
         Self {
             repository,
@@ -569,6 +575,7 @@ impl GitReleasePin {
             version_upper_bound,
             release_prefix,
             submodules,
+            lfs,
         }
     }
 }
@@ -1042,6 +1049,7 @@ mod test {
             version_upper_bound: None,
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1101,6 +1109,7 @@ mod test {
             version_upper_bound: None,
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1140,6 +1149,7 @@ mod test {
             version_upper_bound: None,
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = GenericVersion {
             version: "0.2.1".into(),
@@ -1200,6 +1210,7 @@ mod test {
             version_upper_bound: Some("2.90.1".to_string()),
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1265,6 +1276,7 @@ mod test {
             version_upper_bound: None,
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1301,6 +1313,7 @@ mod test {
             version_upper_bound: None,
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = GenericVersion {
             version: "40.0".into(),
@@ -1361,6 +1374,7 @@ mod test {
             version_upper_bound: None,
             release_prefix: None,
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(

--- a/libnpins/src/pins/git.rs
+++ b/libnpins/src/pins/git.rs
@@ -431,6 +431,9 @@ pub struct GitPin {
     /// Also fetch submodules
     #[serde(default)]
     pub submodules: bool,
+    /// Also fetch LFS references
+    #[serde(default)]
+    pub lfs: bool,
 }
 
 impl diff::Diff for GitPin {
@@ -447,11 +450,12 @@ impl diff::Diff for GitPin {
 }
 
 impl GitPin {
-    pub fn new(repository: Repository, branch: String, submodules: bool) -> Self {
+    pub fn new(repository: Repository, branch: String, submodules: bool, lfs: bool) -> Self {
         Self {
             repository,
             branch,
             submodules,
+            lfs,
         }
     }
 }
@@ -1008,6 +1012,7 @@ mod test {
             },
             branch: "master".into(),
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1066,6 +1071,7 @@ mod test {
             },
             branch: "master".into(),
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1163,6 +1169,7 @@ mod test {
             },
             branch: "release-2.90".into(),
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1227,6 +1234,7 @@ mod test {
             },
             branch: "master".into(),
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(
@@ -1322,6 +1330,7 @@ mod test {
             },
             branch: "master".into(),
             submodules: false,
+            lfs: false,
         };
         let version = pin.update(None).await?;
         assert_eq!(

--- a/libnpins/src/pins/git.rs
+++ b/libnpins/src/pins/git.rs
@@ -477,7 +477,7 @@ impl Updatable for GitPin {
     }
 
     async fn fetch(&self, version: &GitRevision) -> Result<OptionalUrlHashes> {
-        if self.submodules {
+        if self.submodules || self.lfs {
             Ok(OptionalUrlHashes {
                 url: None,
                 hash: nix::nix_prefetch_git(&self.repository.git_url()?, &version.revision, true)
@@ -655,7 +655,7 @@ impl Updatable for GitReleasePin {
             .await?
             .revision;
 
-        if self.submodules {
+        if self.submodules || self.lfs {
             Ok(ReleasePinHashes {
                 url: None,
                 hash: nix::nix_prefetch_git(&repo_url, &revision, true).await?,

--- a/libnpins/src/versions.rs
+++ b/libnpins/src/versions.rs
@@ -418,13 +418,13 @@ mod test {
             NixPins {
                 pins: btreemap![
                     "nixos-mailserver".into() => Pin::Git {
-                        input: git::GitPin::new(git::Repository::git("https://gitlab.com/simple-nixos-mailserver/nixos-mailserver.git".parse().unwrap()), "nixos-21.11".into(), false),
+                        input: git::GitPin::new(git::Repository::git("https://gitlab.com/simple-nixos-mailserver/nixos-mailserver.git".parse().unwrap()), "nixos-21.11".into(), false, false),
                         version: Some(git::GitRevision::new("6e3a7b2ea6f0d68b82027b988aa25d3423787303".into()).unwrap()),
                         hashes: Some(git::OptionalUrlHashes { url: None, hash: NixHash::from_sri("sha256-hNhzLOp+dApEY15vwLAQZu+sjEQbJcOXCaSfAT6lpsQ=").unwrap() } ),
                         frozen: Frozen::default(),
                     },
                     "nixpkgs".into() => Pin::Git {
-                        input: git::GitPin::new(git::Repository::github("nixos", "nixpkgs"), "nixpkgs-unstable".into(), false),
+                        input: git::GitPin::new(git::Repository::github("nixos", "nixpkgs"), "nixpkgs-unstable".into(), false, false),
                         version: Some(git::GitRevision::new("5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2".into()).unwrap()),
                         hashes: Some(git::OptionalUrlHashes { url: Some("https://github.com/nixos/nixpkgs/archive/5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2.tar.gz".parse().unwrap()), hash: NixHash::from_sri("sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=").unwrap() }),
                         frozen: Frozen::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ impl GenericGitAddOpts {
                     self.version_upper_bound.clone(),
                     self.release_prefix.clone(),
                     self.submodules,
+                    self.lfs,
                 );
                 let version = self.at.as_ref().map(|at| GenericVersion {
                     version: at.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ impl GenericGitAddOpts {
     fn add(&self, repository: git::Repository) -> Result<Pin> {
         Ok(match &self.branch {
             Some(branch) => {
-                let pin = git::GitPin::new(repository, branch.clone(), self.submodules);
+                let pin = git::GitPin::new(repository, branch.clone(), self.submodules, self.lfs);
                 let version = self
                     .at
                     .as_ref()

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -63,6 +63,10 @@ pub struct GenericGitAddOpts {
     /// Also fetch submodules
     #[arg(long)]
     pub submodules: bool,
+
+    /// Also fetch LFS references
+    #[arg(long)]
+    pub lfs: bool,
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Just adds a field called `lfs` to git pins defaulting to `false` that is forwarded to `builtins.fetchGit`. `fetchGit` has had the `lfs` argument since `2.27`.

My concern is if this should be accompanied by a bump in the pins sources version?

It's also important to consider that the nar hash depends on whether lfs is enabled or not, even for the same revisions.

I made sure to run all commit and push hooks, code is formatted and readme updated. Tested and works for my personal use, this is ready to merge.