### PR TITLE
add patches attribute for pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Pins now optionally take a patches attribute and apply them using pkgs.applyPatches
+
 ## 0.5.0
 
 - **[Breaking] Support for the "Lockable HTTP Tarball Protocol" has been removed.**

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Simple and convenient dependency pinning for Nix
   - Unlike tracking a channel from its git branch, this gives you access to the `programs.sqlite` database
   - Can also track Nix channel artifacts like live isos
 - Track PyPi packages
+- Patch pins with pkgs.applyPatches
 
 ## Getting Started
 
@@ -437,6 +438,26 @@ let
 in
 sources.mySource { inherit pkgs; }
 ```
+
+### Applying patches to pins
+
+Since there's no Nix builtin for applying patches, we need to rely on nixpkgs.
+Then you can pass patches as a list of patch files.
+
+```nix
+let
+  sources = import ./npins;
+  bootstrapPkgs = import sources.nixpkgs { };
+  patchedNixpkgs = sources.nixpkgs {
+    pkgs = bootstrapPkgs;
+    patches = [ ./my_nixpkgs.patch ];
+  };
+  pkgs = import patchedNixpkgs {};
+in pkgs.hello
+```
+
+The unpatched version is exposed as nixpkgs.unpatchedPath, while outPath is overridden with the patched version.
+You can also use something like `lib.mapAttrs` together with `builtins.readDir` to apply patches dynamically. :)
 
 ### Running the latest unreleased `npins`
 

--- a/README.md.in
+++ b/README.md.in
@@ -25,6 +25,7 @@ Simple and convenient dependency pinning for Nix
   - Unlike tracking a channel from its git branch, this gives you access to the `programs.sqlite` database
   - Can also track Nix channel artifacts like live isos
 - Track PyPi packages
+- Patch pins with pkgs.applyPatches
 
 ## Getting Started
 
@@ -259,6 +260,26 @@ let
 in
 sources.mySource { inherit pkgs; }
 ```
+
+### Applying patches to pins
+
+Since there's no Nix builtin for applying patches, we need to rely on nixpkgs.
+Then you can pass patches as a list of patch files.
+
+```nix
+let
+  sources = import ./npins;
+  bootstrapPkgs = import sources.nixpkgs { };
+  patchedNixpkgs = sources.nixpkgs {
+    pkgs = bootstrapPkgs;
+    patches = [ ./my_nixpkgs.patch ];
+  };
+  pkgs = import patchedNixpkgs {};
+in pkgs.hello
+```
+
+The unpatched version is exposed as nixpkgs.unpatchedPath, while outPath is overridden with the patched version.
+You can also use something like `lib.mapAttrs` together with `builtins.readDir` to apply patches dynamically. :)
 
 ### Running the latest unreleased `npins`
 

--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -38,24 +38,26 @@ let
     let
       envVarName = "NPINS_OVERRIDE_${saneName}";
       saneName = stringAsChars (c: if (builtins.match "[a-zA-Z0-9]" c) == null then "_" else c) name;
-      ersatz = builtins.getEnv envVarName;
+      replacement = builtins.getEnv envVarName;
     in
-    if ersatz == "" then
+    if replacement == "" then
       path
     else
       # this turns the string into an actual Nix path (for both absolute and
       # relative paths)
-      builtins.trace "Overriding path of \"${name}\" with \"${ersatz}\" due to set \"${envVarName}\"" (
-        if builtins.substring 0 1 ersatz == "/" then
-          /. + ersatz
-        else
-          /. + builtins.getEnv "PWD" + "/${ersatz}"
-      );
+      builtins.trace "Overriding path of \"${name}\" with \"${replacement}\" due to set \"${envVarName}\""
+        (
+          if builtins.substring 0 1 replacement == "/" then
+            /. + replacement
+          else
+            /. + builtins.getEnv "PWD" + "/${replacement}"
+        );
 
   mkSource =
     name: spec:
     {
       pkgs ? null,
+      patches ? [ ],
     }:
     assert spec ? type;
     let
@@ -98,22 +100,34 @@ let
           };
 
       path =
-        if spec.type == "Git" then
-          mkGitSource fetchers spec
-        else if spec.type == "GitRelease" then
-          mkGitSource fetchers spec
-        else if spec.type == "PyPi" then
-          mkPyPiSource fetchers spec
-        else if spec.type == "Channel" then
-          mkChannelSource fetchers spec
-        else if spec.type == "Url" || spec.type == "MutableUrl" then
-          mkUrlSource fetchers spec
-        else if spec.type == "Container" then
-          mkContainerSource pkgs spec
+        {
+          "Git" = mkGitSource fetchers spec;
+          "GitRelease" = mkGitSource fetchers spec;
+          "PyPi" = mkPyPiSource fetchers spec;
+          "Channel" = mkChannelSource fetchers spec;
+          "Url" = mkUrlSource fetchers spec;
+          "MutableUrl" = mkUrlSource fetchers spec;
+          "Container" = mkContainerSource pkgs spec;
+        }
+        .${spec.type} or (builtins.throw "Unknown source type ${spec.type}");
+
+      overridePath = mayOverride name path;
+      patchedPath =
+        if patches == [ ] then
+          overridePath
+        else if pkgs != null then
+          pkgs.applyPatches {
+            inherit name patches;
+            src = overridePath;
+          }
         else
-          builtins.throw "Unknown source type ${spec.type}";
+          builtins.throw "${name}: pkgs is required to apply patches";
     in
-    spec // { outPath = mayOverride name path; };
+    spec
+    // {
+      outPath = patchedPath;
+      unpatchedPath = overridePath;
+    };
 
   mkGitSource =
     {

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ let
   pre-commit = (import pins."pre-commit-hooks.nix").run {
     src = ./.;
     hooks = {
-      nixfmt-rfc-style = {
+      nixfmt = {
         enable = true;
         settings.width = 100;
       };

--- a/test.nix
+++ b/test.nix
@@ -874,7 +874,7 @@ in
       '';
     };
 
-  gitDependencyOverride = mkGitTest rec {
+  gitDependencyOverride = mkGitTest {
     name = "git-dependency-override";
     repositories."foo" = gitRepo;
     commands = ''
@@ -891,7 +891,7 @@ in
   };
 
   # https://github.com/andir/npins/issues/75
-  regression_issue75 = mkGitTest rec {
+  regression_issue75 = mkGitTest {
     name = "regression-issue-75";
     repositories."foo" = gitRepo;
     commands = ''
@@ -902,7 +902,7 @@ in
     '';
   };
 
-  getPath = mkGitTest rec {
+  getPath = mkGitTest {
     name = "get-path";
     repositories."foo" = gitRepo;
     commands = ''
@@ -914,4 +914,32 @@ in
       eq "$(nix-instantiate --eval npins -A foo.outPath)" "\"$(npins get-path foo)\""
     '';
   };
+  applyPatch =
+    let
+      patchFile = pkgs.writeText "my.patch" ''
+        diff --git a/test.txt b/test.txt
+        index e69de29..980a0d5 100644
+        --- a/test.txt
+        +++ b/test.txt
+        @@ -0,0 +1 @@
+        +Hello World!
+      '';
+    in
+    mkGitTest {
+      name = "apply-patch";
+      repositories."foo" = gitRepo;
+      commands = ''
+        npins init --bare
+        npins add git http://localhost:8000/foo -b test-branch
+        npins show
+        set +x
+
+        RESULT=$(nix-instantiate --eval --json --strict --expr 'let pkgs = import ${pins.nixpkgs} {}; pins = import ./npins; foo = pins.foo { inherit pkgs; patches = [ ${patchFile} ]; }; in { patchedPath = foo.outPath; unpatchedPath = foo.unpatchedPath; }')
+
+        OUTPATH=$(echo "$RESULT" | ${pkgs.jq}/bin/jq -r .patchedPath)
+        UNPATCHEDPATH=$(echo "$RESULT" | ${pkgs.jq}/bin/jq -r .unpatchedPath)
+
+        neq $OUTPATH $UNPATCHEDPATH
+      '';
+    };
 }


### PR DESCRIPTION
Some glue code to make patching pins more convenient, motivated by  #141.

I'm not too happy with passing pkgs and patches to every pin individually, but that seems like the most obvious path forward, since the api already exists.

Also, not sure if we want to couple patches and nixpkgs fetchers.
If we want to decouple them, but keep the same api, I'd probably add an attribute like `nixpkgsFetcher ? true` to `mkSource`. This would keep the existing api compatible but would also allow the user to toggle the behavior if they wish to. I can imagine this being useful for the nixpkgs pin, so you can patch it without having to fetch it twice.

The test is a bit shit, before merging it should probably be improved. Currently, if the patch can't be applied it still succeeds and is completely silent about the failure in the logs (bash is horrible).