### PR TITLE
Avoid mutable URL store path being too long

### DIFF
--- a/libnpins/src/default.nix
+++ b/libnpins/src/default.nix
@@ -107,7 +107,7 @@ let
         else if spec.type == "Channel" then
           mkChannelSource fetchers spec
         else if spec.type == "Url" || spec.type == "MutableUrl" then
-          mkUrlSource fetchers spec
+          mkUrlSource fetchers name spec
         else if spec.type == "Container" then
           mkContainerSource pkgs spec
         else
@@ -199,6 +199,7 @@ let
       fetchurl,
       ...
     }:
+    name:
     {
       url,
       hash,
@@ -206,7 +207,7 @@ let
       ...
     }:
     (if unpack then fetchTarball else fetchurl) {
-      inherit url;
+      inherit url name;
       sha256 = hash;
     };
 


### PR DESCRIPTION
Fixes: #244 

Not sure if there is a clearer/more idiomatic way to solve this.
A fix of some kind is needed to avoid the long names given by the use of fully resolved URLs and the inclusion of query parameters in `fetchurl` name detection, since store paths have limited length (211 chars).

Using the pin's name, which must (afaict) be supplied manually for mutable URLs, seems like a good compromise of should-always-work and is-accurate.

Of course, supplying a needlessly long name will still break this, but that's a reasonable "give very long pin name" -> "store path is too long" error, which seems like good enough UX.

~~I'm not familiar enough with npins to know if this is the correct way to bump the vendored `default.nix` version, but it does seem like it would be necessary here to cause a prompt about the change.~~
This shouldn't actually be a breaking change, unless someone is actually relying on the store path for a mutable URL pin having a specific structure from the underlying URL... that seems like not really a part of the API contract, though.